### PR TITLE
My Raffles 전반 API 연동

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -12,6 +12,7 @@ import { Plus, X, Gift, Users } from 'lucide-react'
 import { createRaffleSchema, type CreateRaffleFormData } from '@/lib/schemas'
 import { useCreateRaffle } from '@/hooks/useCreateRaffle'
 import { useToast } from '@/components/ui/Toast'
+import type { CreateRaffleRequest } from '@/types'
 
 export default function CreatePage() {
 	const router = useRouter()
@@ -61,33 +62,41 @@ export default function CreatePage() {
 				'https://images.unsplash.com/photo-1615592389070-bcc97e05ad01?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=1080',
 		}))
 
-		createRaffle.mutate(
-			{
-				...data,
-				deadlineAt,
-				imageUrl,
-				tiers,
+		// externalSeedDescription은 명세에 없으나 백엔드가 허용하면 전송
+		// 비어있으면 제외하여 400 에러 방지
+		const requestPayload: CreateRaffleRequest = {
+			title: data.title,
+			description: data.description,
+			entryFee: data.entryFee,
+			minParticipants: data.minParticipants,
+			maxParticipants: data.maxParticipants,
+			deadlineAt,
+			imageUrl,
+			tiers,
+			...(data.externalSeedDescription && {
+				externalSeedDescription: data.externalSeedDescription,
+			}),
+		}
+
+		createRaffle.mutate(requestPayload, {
+			onSuccess: () => {
+				addToast({
+					title: '등록 완료',
+					description: '성공적으로 등록되었습니다',
+					variant: 'success',
+					duration: 3000,
+				})
+				router.push('/')
 			},
-			{
-				onSuccess: () => {
-					addToast({
-						title: '등록 완료',
-						description: '성공적으로 등록되었습니다',
-						variant: 'success',
-						duration: 3000,
-					})
-					router.push('/')
-				},
-				onError: () => {
-					addToast({
-						title: '등록 실패',
-						description: '추첨 등록에 실패했습니다. 다시 시도해주세요.',
-						variant: 'error',
-						duration: 4000,
-					})
-				},
+			onError: () => {
+				addToast({
+					title: '등록 실패',
+					description: '추첨 등록에 실패했습니다. 다시 시도해주세요.',
+					variant: 'error',
+					duration: 4000,
+				})
 			},
-		)
+		})
 	}
 
 	const onInvalid = (errors: Record<string, { message?: string }>) => {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,13 +1,13 @@
 import { Suspense } from 'react'
-import { serverApiClient } from '@/lib/api-server'
+import { myApi } from '@/lib/api'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 import { DashboardPageClient } from '@/components/pages/DashboardPageClient'
 
 export default async function Dashboard() {
 	// 모의 API로 등록/참여 목록을 병렬 prefetch
 	const [myRafflesData, participatedRafflesData] = await Promise.all([
-		serverApiClient.getMyHostedRaffles(),
-		serverApiClient.getMyParticipatedRaffles(),
+		myApi.getHostedRaffles(),
+		myApi.getParticipatedRaffles(),
 	])
 
 	return (

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,9 +4,11 @@ import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 import { DashboardPageClient } from '@/components/pages/DashboardPageClient'
 
 export default async function Dashboard() {
-	// 모의 API로 내가 등록한 추첨 목록만 우선 prefetch
-	const [myRafflesData] = await Promise.all([serverApiClient.getMyHostedRaffles()])
-	const participatedRafflesData: never[] = []
+	// 모의 API로 등록/참여 목록을 병렬 prefetch
+	const [myRafflesData, participatedRafflesData] = await Promise.all([
+		serverApiClient.getMyHostedRaffles(),
+		serverApiClient.getMyParticipatedRaffles(),
+	])
 
 	return (
 		<div className="bg-background min-h-screen">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,17 +1,11 @@
 import { Suspense } from 'react'
-// import { serverApiClient } from '@/lib/api-server'
+import { serverApiClient } from '@/lib/api-server'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 import { DashboardPageClient } from '@/components/pages/DashboardPageClient'
 
 export default async function Dashboard() {
-	// ❌ API 명세에 없는 엔드포인트 (백엔드 확인 필요)
-	// const [myRafflesData, participatedRafflesData] = await Promise.all([
-	// 	serverApiClient.getMyRaffles(),
-	// 	serverApiClient.getParticipatedRaffles(),
-	// ])
-
-	// 임시로 빈 데이터 전달
-	const myRafflesData: never[] = []
+	// 모의 API로 내가 등록한 추첨 목록만 우선 prefetch
+	const [myRafflesData] = await Promise.all([serverApiClient.getMyHostedRaffles()])
 	const participatedRafflesData: never[] = []
 
 	return (

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,9 +5,10 @@ import { DashboardPageClient } from '@/components/pages/DashboardPageClient'
 
 export default async function Dashboard() {
 	// 모의 API로 등록/참여 목록을 병렬 prefetch
-	const [myRafflesData, participatedRafflesData] = await Promise.all([
+	const [myRafflesData, participatedRafflesData, myWinsData] = await Promise.all([
 		myApi.getHostedRaffles(),
 		myApi.getParticipatedRaffles(),
+		myApi.getWins(),
 	])
 
 	return (
@@ -16,6 +17,7 @@ export default async function Dashboard() {
 				<DashboardPageClient
 					initialMyRaffles={myRafflesData}
 					initialParticipatedRaffles={participatedRafflesData}
+					initialWins={myWinsData.wins}
 				/>
 			</Suspense>
 		</div>

--- a/src/app/my/raffles/[raffleId]/result/page.tsx
+++ b/src/app/my/raffles/[raffleId]/result/page.tsx
@@ -1,4 +1,4 @@
-import { serverApiClient } from '@/lib/api-server'
+import { myApi } from '@/lib/api'
 import type { MyRaffleSelfResultResponse } from '@/types'
 
 interface PageProps {
@@ -12,7 +12,7 @@ export const metadata = {
 
 export default async function MyRaffleSelfResultPage({ params }: PageProps) {
 	const { raffleId } = await params
-	const data: MyRaffleSelfResultResponse = await serverApiClient.getMyRaffleSelfResult(raffleId)
+	const data: MyRaffleSelfResultResponse = await myApi.getSelfResult(raffleId)
 
 	return (
 		<div className="container mx-auto px-4 py-8">

--- a/src/app/my/raffles/[raffleId]/result/page.tsx
+++ b/src/app/my/raffles/[raffleId]/result/page.tsx
@@ -1,5 +1,6 @@
 import { myApi } from '@/lib/api'
 import type { MyRaffleSelfResultResponse } from '@/types'
+import Image from 'next/image'
 
 interface PageProps {
 	params: Promise<{ raffleId: string }>
@@ -16,50 +17,99 @@ export default async function MyRaffleSelfResultPage({ params }: PageProps) {
 
 	return (
 		<div className="container mx-auto px-4 py-8">
-			<h1 className="text-foreground mb-6 text-2xl font-semibold">내 결과</h1>
-			<div className="rounded-xl border p-6">
-				<div className="mb-4">
-					<div className="text-muted-foreground text-sm">래플</div>
-					<div className="text-lg font-medium">{data.raffleName || data.raffleId}</div>
-				</div>
-				<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-					<div>
-						<div className="text-muted-foreground text-sm">내 표시 이름</div>
-						<div className="font-medium">{data.myParticipation.displayName || '-'}</div>
+			<div className="mb-6 flex items-center justify-between">
+				<h1 className="text-foreground text-2xl font-semibold">내 결과</h1>
+				<span
+					className={`rounded-full px-3 py-1 text-xs ${
+						data.status === 'DRAWN'
+							? 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200'
+							: 'bg-gray-50 text-gray-700 ring-1 ring-gray-200'
+					}`}
+				>
+					상태: {data.status}
+				</span>
+			</div>
+
+			<div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+				{/* 좌: 래플/참여 정보 */}
+				<div className="bg-card rounded-xl border p-6 lg:col-span-2">
+					<div className="mb-4">
+						<div className="text-muted-foreground text-sm">래플</div>
+						<div className="truncate text-lg font-semibold">{data.raffleName || data.raffleId}</div>
 					</div>
-					<div>
-						<div className="text-muted-foreground text-sm">참여 시간</div>
-						<div className="font-medium">
-							{new Date(data.myParticipation.joinedAt).toLocaleString('ko-KR')}
+
+					<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+						<div>
+							<div className="text-muted-foreground text-sm">내 표시 이름</div>
+							<div className="font-medium">{data.myParticipation.displayName || '-'}</div>
 						</div>
-					</div>
-					<div>
-						<div className="text-muted-foreground text-sm">당첨 여부</div>
-						<div className="font-medium">{data.isWinner ? '당첨' : '미당첨'}</div>
-					</div>
-					<div>
-						<div className="text-muted-foreground text-sm">배송 필요</div>
-						<div className="font-medium">{data.shippingRequired ? '예' : '아니오'}</div>
-					</div>
-					<div>
-						<div className="text-muted-foreground text-sm">배송 정보 제출</div>
-						<div className="font-medium">{data.shippingSubmitted ? '완료' : '미제출'}</div>
+						<div>
+							<div className="text-muted-foreground text-sm">참여 시간</div>
+							<div className="font-medium">
+								{new Date(data.myParticipation.joinedAt).toLocaleString('ko-KR')}
+							</div>
+						</div>
+						<div>
+							<div className="text-muted-foreground text-sm">당첨 여부</div>
+							<div
+								className={`font-semibold ${data.isWinner ? 'text-emerald-600' : 'text-gray-600'}`}
+							>
+								{data.isWinner ? '당첨' : '미당첨'}
+							</div>
+						</div>
+						<div className="flex items-center gap-6">
+							<div>
+								<div className="text-muted-foreground text-sm">배송 필요</div>
+								<div className="font-medium">{data.shippingRequired ? '예' : '아니오'}</div>
+							</div>
+							<div>
+								<div className="text-muted-foreground text-sm">배송 정보 제출</div>
+								<div className="font-medium">{data.shippingSubmitted ? '완료' : '미제출'}</div>
+							</div>
+						</div>
 					</div>
 				</div>
 
-				{data.winInfo && (
-					<div className="mt-6 rounded-lg border p-4">
-						<div className="text-muted-foreground mb-2 text-sm">당첨 정보</div>
-						<div className="text-lg font-semibold">
-							#{data.winInfo.rank} {data.winInfo.prizeName}
-						</div>
-						{data.winInfo.prizeImageUrl && (
-							<div className="text-muted-foreground mt-2 text-sm break-all">
-								이미지: {data.winInfo.prizeImageUrl}
-							</div>
+				{/* 우: 당첨 정보+이미지 */}
+				<div className="bg-card rounded-xl border p-6">
+					<div className="mb-4 flex items-center justify-between">
+						<div className="text-muted-foreground text-sm">당첨 정보</div>
+						{data.winInfo ? (
+							<span className="rounded-full bg-amber-50 px-3 py-1 text-xs text-amber-700 ring-1 ring-amber-200">
+								WIN #{data.winInfo.rank}
+							</span>
+						) : (
+							<span className="rounded-full bg-gray-50 px-3 py-1 text-xs text-gray-600 ring-1 ring-gray-200">
+								정보 없음
+							</span>
 						)}
 					</div>
-				)}
+
+					{data.winInfo ? (
+						<>
+							<div className="mb-3 text-lg font-semibold">{data.winInfo.prizeName}</div>
+							<div className="bg-muted relative aspect-square w-full overflow-hidden rounded-lg border">
+								{data.winInfo.prizeImageUrl ? (
+									<Image
+										src={data.winInfo.prizeImageUrl}
+										alt={data.winInfo.prizeName}
+										fill
+										sizes="(max-width: 768px) 100vw, 33vw"
+										className="object-cover"
+									/>
+								) : (
+									<div className="text-muted-foreground flex h-full w-full items-center justify-center text-sm">
+										이미지 없음
+									</div>
+								)}
+							</div>
+						</>
+					) : (
+						<div className="text-muted-foreground text-sm">
+							아직 당첨 정보가 없습니다. 추첨 결과 공개 후 다시 확인해 주세요.
+						</div>
+					)}
+				</div>
 			</div>
 		</div>
 	)

--- a/src/app/my/raffles/[raffleId]/result/page.tsx
+++ b/src/app/my/raffles/[raffleId]/result/page.tsx
@@ -1,0 +1,66 @@
+import { serverApiClient } from '@/lib/api-server'
+import type { MyRaffleSelfResultResponse } from '@/types'
+
+interface PageProps {
+	params: Promise<{ raffleId: string }>
+}
+
+export const metadata = {
+	title: '내 결과 - 가차추첨',
+	description: '해당 래플에서 나의 당첨 여부와 정보를 확인하세요.',
+}
+
+export default async function MyRaffleSelfResultPage({ params }: PageProps) {
+	const { raffleId } = await params
+	const data: MyRaffleSelfResultResponse = await serverApiClient.getMyRaffleSelfResult(raffleId)
+
+	return (
+		<div className="container mx-auto px-4 py-8">
+			<h1 className="text-foreground mb-6 text-2xl font-semibold">내 결과</h1>
+			<div className="rounded-xl border p-6">
+				<div className="mb-4">
+					<div className="text-muted-foreground text-sm">래플</div>
+					<div className="text-lg font-medium">{data.raffleName || data.raffleId}</div>
+				</div>
+				<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+					<div>
+						<div className="text-muted-foreground text-sm">내 표시 이름</div>
+						<div className="font-medium">{data.myParticipation.displayName || '-'}</div>
+					</div>
+					<div>
+						<div className="text-muted-foreground text-sm">참여 시간</div>
+						<div className="font-medium">
+							{new Date(data.myParticipation.joinedAt).toLocaleString('ko-KR')}
+						</div>
+					</div>
+					<div>
+						<div className="text-muted-foreground text-sm">당첨 여부</div>
+						<div className="font-medium">{data.isWinner ? '당첨' : '미당첨'}</div>
+					</div>
+					<div>
+						<div className="text-muted-foreground text-sm">배송 필요</div>
+						<div className="font-medium">{data.shippingRequired ? '예' : '아니오'}</div>
+					</div>
+					<div>
+						<div className="text-muted-foreground text-sm">배송 정보 제출</div>
+						<div className="font-medium">{data.shippingSubmitted ? '완료' : '미제출'}</div>
+					</div>
+				</div>
+
+				{data.winInfo && (
+					<div className="mt-6 rounded-lg border p-4">
+						<div className="text-muted-foreground mb-2 text-sm">당첨 정보</div>
+						<div className="text-lg font-semibold">
+							#{data.winInfo.rank} {data.winInfo.prizeName}
+						</div>
+						{data.winInfo.prizeImageUrl && (
+							<div className="text-muted-foreground mt-2 text-sm break-all">
+								이미지: {data.winInfo.prizeImageUrl}
+							</div>
+						)}
+					</div>
+				)}
+			</div>
+		</div>
+	)
+}

--- a/src/app/my/raffles/wins/page.tsx
+++ b/src/app/my/raffles/wins/page.tsx
@@ -1,0 +1,41 @@
+import { serverApiClient } from '@/lib/api-server'
+import { ShippingStatusBadge } from '@/components/dashboard/ShippingStatusBadge'
+import type { ShippingStatus } from '@/types/dashboard'
+
+export const metadata = {
+	title: '내 당첨 목록 - 가차추첨',
+	description: '내가 당첨된 모든 추첨을 확인하세요.',
+}
+
+export default async function MyWinsPage() {
+	const { wins } = await serverApiClient.getMyWins()
+
+	return (
+		<div className="container mx-auto px-4 py-8">
+			<h1 className="text-foreground mb-6 text-2xl font-semibold">내 당첨 목록</h1>
+			{wins.length === 0 ? (
+				<div className="text-muted-foreground rounded-xl border p-10 text-center">
+					당첨 이력이 없습니다.
+				</div>
+			) : (
+				<div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+					{wins.map((win) => (
+						<div key={win.raffleId} className="rounded-xl border p-5">
+							<div className="text-muted-foreground mb-2 text-sm">{win.raffleName}</div>
+							<div className="text-lg font-semibold">
+								#{win.rank} {win.prizeName}
+							</div>
+							<div className="mt-3 flex items-center justify-between text-sm">
+								<span className="text-muted-foreground">추첨일</span>
+								<span className="font-medium">{new Date(win.drawnAt).toLocaleString('ko-KR')}</span>
+							</div>
+							<div className="mt-2">
+								<ShippingStatusBadge status={win.shippingStatus as ShippingStatus} />
+							</div>
+						</div>
+					))}
+				</div>
+			)}
+		</div>
+	)
+}

--- a/src/app/my/raffles/wins/page.tsx
+++ b/src/app/my/raffles/wins/page.tsx
@@ -1,4 +1,4 @@
-import { serverApiClient } from '@/lib/api-server'
+import { myApi } from '@/lib/api'
 import { ShippingStatusBadge } from '@/components/dashboard/ShippingStatusBadge'
 import type { ShippingStatus } from '@/types/dashboard'
 
@@ -8,7 +8,7 @@ export const metadata = {
 }
 
 export default async function MyWinsPage() {
-	const { wins } = await serverApiClient.getMyWins()
+	const { wins } = await myApi.getWins()
 
 	return (
 		<div className="container mx-auto px-4 py-8">

--- a/src/app/raffle/[id]/RaffleDetailClient.tsx
+++ b/src/app/raffle/[id]/RaffleDetailClient.tsx
@@ -22,7 +22,6 @@ import { Clock, Users, CheckCircle, AlertCircle } from 'lucide-react'
 import { formatTimeLeft, formatPrice } from '@/lib/utils'
 import { RAFFLE_DETAIL_UI_TEXT } from '@/lib/constants'
 import { useRaffleDetail } from '@/hooks/useRaffleDetail'
-import { useParticipants } from '@/hooks/useParticipants'
 import { participantApi } from '@/lib/api'
 import { useQueryClient } from '@tanstack/react-query'
 import { useToast } from '@/components/ui/Toast'
@@ -71,9 +70,8 @@ export function RaffleDetailClient({ id }: RaffleDetailClientProps) {
 	const [currentTime, setCurrentTime] = useState(Date.now())
 	const [hasParticipated, setHasParticipated] = useState(false)
 
-	// 실제 API 호출
+	// 실제 API 호출 - participantDisplayNames는 상세 API에 포함되므로 중복 호출 불필요
 	const { data: raffleData, isLoading, isError } = useRaffleDetail(id)
-	const { data: participantsData } = useParticipants(id)
 
 	// 1초마다 현재 시간 업데이트 (실시간 남은 시간 표시를 위해)
 	useEffect(() => {
@@ -85,17 +83,17 @@ export function RaffleDetailClient({ id }: RaffleDetailClientProps) {
 	const raffle = useMemo((): RaffleDetail | null => {
 		if (!raffleData) return null
 
-		// 참여자 수는 participantsData.count 우선 사용 (가장 정확)
-		const currentParticipants = participantsData?.count ?? raffleData.participantsCount
+		// 참여자 수는 participantDisplayNames 배열 길이로 계산
+		const currentParticipants = raffleData.participantDisplayNames.length
 
-		// 실제 참여자 목록 사용
-		const participants: Participant[] = participantsData?.participants
-			? participantsData.participants.map((p) => ({
-					id: p.participantId,
-					displayName: p.displayName,
-					joinedAt: new Date(p.joinedAt),
-				}))
-			: []
+		// 참여자 목록은 participantDisplayNames에서 직접 생성
+		const participants: Participant[] = raffleData.participantDisplayNames.map(
+			(displayName, index) => ({
+				id: `participant-${index}`, // 실제 ID는 없으므로 임시 생성
+				displayName,
+				joinedAt: new Date(), // 상세 정보 없으므로 현재 시간 사용
+			}),
+		)
 
 		return {
 			id: raffleData.id,
@@ -118,7 +116,7 @@ export function RaffleDetailClient({ id }: RaffleDetailClientProps) {
 			participants,
 			externalSeed: raffleData.externalSeed || raffleData.externalSeedDescription,
 		}
-	}, [raffleData, participantsData])
+	}, [raffleData])
 
 	const handleParticipate = async () => {
 		if (!participantName.trim()) {
@@ -216,8 +214,7 @@ export function RaffleDetailClient({ id }: RaffleDetailClientProps) {
 				displayName: participantName,
 			})
 
-			// 성공 시 참여자 목록 새로고침
-			queryClient.invalidateQueries({ queryKey: ['participants', id] })
+			// 성공 시 래플 상세 새로고침 (participantDisplayNames 포함)
 			queryClient.invalidateQueries({ queryKey: ['raffle', id] })
 
 			addToast({

--- a/src/components/dashboard/ParticipatedRaffleCard.tsx
+++ b/src/components/dashboard/ParticipatedRaffleCard.tsx
@@ -14,6 +14,7 @@ interface ParticipatedRaffleCardProps {
 	raffle: ParticipatedRaffle
 	onViewDetail: (id: string) => void
 	onViewResult: (id: string) => void
+	onViewMyResult?: (id: string) => void
 }
 
 export const ParticipatedRaffleCard = memo(
@@ -63,16 +64,30 @@ export const ParticipatedRaffleCard = memo(
 						</div>
 					</CardHeader>
 					<CardContent className="space-y-4">
-						{/* 참여자 수 정보 (참여한 추첨에서는 표시하지 않음) */}
-						{raffle.status === 'PUBLISHED' && (
-							<div className="flex items-center justify-between text-sm">
-								<span className="flex items-center gap-1" aria-label="참여한 시간">
-									<Clock className="h-4 w-4" />
-									참여 시간
+						{/* 참여 시간 */}
+						<div className="flex items-center justify-between text-sm">
+							<span className="flex items-center gap-1" aria-label="참여한 시간">
+								<Clock className="h-4 w-4" />
+								참여 시간
+							</span>
+							<span>{new Date(raffle.participatedAt).toLocaleString('ko-KR')}</span>
+						</div>
+
+						{/* 참여비 / 마감일 */}
+						<div className="grid grid-cols-2 gap-3 text-sm">
+							<div className="flex items-center justify-between">
+								<span className="text-muted-foreground">참여비</span>
+								<span className="font-medium">
+									{(Number(raffle.entryFee) || 0).toLocaleString('ko-KR')}원
 								</span>
-								<span>{new Date(raffle.participatedAt).toLocaleString('ko-KR')}</span>
 							</div>
-						)}
+							<div className="flex items-center justify-between">
+								<span className="text-muted-foreground">마감일</span>
+								<span className="font-medium">
+									{new Date(raffle.deadlineAt).toLocaleString('ko-KR')}
+								</span>
+							</div>
+						</div>
 
 						{/* 당첨 상품 정보 */}
 						{raffle.isWinner && raffle.itemName && (
@@ -104,14 +119,26 @@ export const ParticipatedRaffleCard = memo(
 								상세보기
 							</Button>
 							{raffle.status === 'DRAWN' && (
-								<Button
-									variant="outline"
-									onClick={drawnButtonCallback ?? undefined}
-									className="flex-1"
-									aria-label={`${drawnLabelText} 버튼 ${raffle.title}`}
-								>
-									{drawnLabelText}
-								</Button>
+								<>
+									<Button
+										variant="outline"
+										onClick={drawnButtonCallback ?? undefined}
+										className="flex-1"
+										aria-label={`${drawnLabelText} 버튼 ${raffle.title}`}
+									>
+										{drawnLabelText}
+									</Button>
+									{onViewMyResult && (
+										<Button
+											variant="outline"
+											onClick={() => onViewMyResult?.(raffle.id)}
+											className="flex-1"
+											aria-label={`내 결과 버튼 ${raffle.title}`}
+										>
+											내 결과
+										</Button>
+									)}
+								</>
 							)}
 						</div>
 					</CardContent>

--- a/src/components/pages/DashboardPageClient.tsx
+++ b/src/components/pages/DashboardPageClient.tsx
@@ -40,9 +40,45 @@ export function DashboardPageClient({
 		formatTimeLeft,
 	} = useDashboard()
 
-	// 서버에서 prefetch된 초기 데이터 사용
-	const displayMyRaffles = initialMyRaffles
-	const displayParticipatedRaffles = initialParticipatedRaffles
+	// 서버에서 prefetch된 초기 데이터를 로컬 상태로 관리 (취소 시 상태만 변경)
+	const [displayMyRaffles, setDisplayMyRaffles] = React.useState(initialMyRaffles)
+	const [displayParticipatedRaffles] = React.useState(initialParticipatedRaffles)
+
+	const handleLockAndMarkLocked = React.useCallback(
+		async (raffleId: string) => {
+			const ok = await handleLockRaffle(raffleId)
+			if (ok) {
+				setDisplayMyRaffles((prev) =>
+					prev.map((r) => (r.id === raffleId ? { ...r, status: 'LOCKED' } : r)),
+				)
+			}
+		},
+		[handleLockRaffle],
+	)
+
+	const handleCancelAndMarkCancelled = React.useCallback(
+		async (raffleId: string) => {
+			const ok = await handleCancelRaffle(raffleId)
+			if (ok) {
+				setDisplayMyRaffles((prev) =>
+					prev.map((r) => (r.id === raffleId ? { ...r, status: 'CANCELLED' } : r)),
+				)
+			}
+		},
+		[handleCancelRaffle],
+	)
+
+	const handleDrawAndMarkDrawn = React.useCallback(
+		async (raffleId: string) => {
+			const ok = await handleDrawRaffle(raffleId)
+			if (ok) {
+				setDisplayMyRaffles((prev) =>
+					prev.map((r) => (r.id === raffleId ? { ...r, status: 'DRAWN' } : r)),
+				)
+			}
+		},
+		[handleDrawRaffle],
+	)
 
 	return (
 		<div className="container mx-auto px-4 py-8">
@@ -111,9 +147,9 @@ export function DashboardPageClient({
 								<RaffleCard
 									key={raffle.id}
 									raffle={raffle}
-									onLock={handleLockRaffle}
-									onCancel={handleCancelRaffle}
-									onDraw={handleDrawRaffle}
+									onLock={handleLockAndMarkLocked}
+									onCancel={handleCancelAndMarkCancelled}
+									onDraw={handleDrawAndMarkDrawn}
 									onTrackingSubmit={handleTrackingSubmit}
 									formatTimeLeft={formatTimeLeft}
 									router={router}

--- a/src/components/pages/DashboardPageClient.tsx
+++ b/src/components/pages/DashboardPageClient.tsx
@@ -13,15 +13,18 @@ import { useDashboard } from '@/hooks/useDashboard'
 import { DASHBOARD_UI_TEXT } from '@/lib/constants'
 import { Plus, Package, Users } from 'lucide-react'
 import type { MyRaffle, ParticipatedRaffle } from '@/types/dashboard'
+import type { MyWinItem } from '@/types'
 
 interface DashboardPageClientProps {
 	initialMyRaffles: MyRaffle[]
 	initialParticipatedRaffles: ParticipatedRaffle[]
+	initialWins: MyWinItem[]
 }
 
 export function DashboardPageClient({
 	initialMyRaffles,
 	initialParticipatedRaffles,
+	initialWins,
 }: DashboardPageClientProps) {
 	const router = useRouter()
 	const {
@@ -43,6 +46,7 @@ export function DashboardPageClient({
 	// 서버에서 prefetch된 초기 데이터를 로컬 상태로 관리 (취소 시 상태만 변경)
 	const [displayMyRaffles, setDisplayMyRaffles] = React.useState(initialMyRaffles)
 	const [displayParticipatedRaffles] = React.useState(initialParticipatedRaffles)
+	const [displayWins] = React.useState(initialWins)
 
 	const handleLockAndMarkLocked = React.useCallback(
 		async (raffleId: string) => {
@@ -88,7 +92,7 @@ export function DashboardPageClient({
 			</div>
 
 			<Tabs defaultValue="my-raffles" className="space-y-6">
-				<TabsList className="grid w-1/2 grid-cols-2" role="tablist">
+				<TabsList className="grid w-full grid-cols-3 md:w-2/3" role="tablist">
 					<TabsTrigger
 						value="my-raffles"
 						className="w-full"
@@ -104,6 +108,14 @@ export function DashboardPageClient({
 						aria-controls="participated-content"
 					>
 						{DASHBOARD_UI_TEXT.PARTICIPATED_TAB}
+					</TabsTrigger>
+					<TabsTrigger
+						value="my-wins"
+						className="w-full"
+						role="tab"
+						aria-controls="my-wins-content"
+					>
+						내 당첨
 					</TabsTrigger>
 				</TabsList>
 
@@ -154,6 +166,70 @@ export function DashboardPageClient({
 									formatTimeLeft={formatTimeLeft}
 									router={router}
 								/>
+							))}
+						</div>
+					)}
+				</TabsContent>
+
+				{/* 내 당첨 목록 */}
+				<TabsContent
+					value="my-wins"
+					className="space-y-6"
+					id="my-wins-content"
+					role="tabpanel"
+					aria-labelledby="my-wins-tab"
+				>
+					<h2 className="text-xl font-semibold" aria-label={`내 당첨 개수 ${displayWins.length}`}>
+						내 당첨 ({displayWins.length})
+					</h2>
+
+					{displayWins.length === 0 ? (
+						<Card className="text-center" aria-label="내 당첨이 없음을 알리는 카드">
+							<CardContent className="py-12">
+								<EmptyState
+									icon={Users}
+									title="당첨 이력이 없습니다"
+									description="추첨에 참여하고 행운의 주인공이 되어보세요."
+									buttonText={DASHBOARD_UI_TEXT.BROWSE_RAFFLES_BUTTON}
+									onButtonClick={() => router.push('/')}
+									ariaLabel="내 당첨이 없음을 알리는 카드"
+								/>
+							</CardContent>
+						</Card>
+					) : (
+						<div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+							{displayWins.map((win) => (
+								<Card key={win.raffleId}>
+									<CardContent className="space-y-3 p-4 md:p-6">
+										<div className="flex items-center justify-between">
+											<div className="text-muted-foreground text-sm">{win.raffleName}</div>
+											<div className="text-muted-foreground text-xs">
+												{new Date(win.drawnAt).toLocaleString('ko-KR')}
+											</div>
+										</div>
+										<div className="text-lg font-semibold">
+											#{win.rank} {win.prizeName}
+										</div>
+										<div className="flex gap-2">
+											<Button
+												variant="outline"
+												className="flex-1"
+												onClick={() => router.push(`/raffles/${win.raffleId}/result`)}
+												aria-label={`${win.raffleName} 결과보기`}
+											>
+												결과보기
+											</Button>
+											<Button
+												variant="outline"
+												className="flex-1"
+												onClick={() => router.push(`/my/raffles/${win.raffleId}/result`)}
+												aria-label={`${win.raffleName} 내 결과`}
+											>
+												내 결과
+											</Button>
+										</div>
+									</CardContent>
+								</Card>
 							))}
 						</div>
 					)}

--- a/src/components/pages/DashboardPageClient.tsx
+++ b/src/components/pages/DashboardPageClient.tsx
@@ -195,6 +195,7 @@ export function DashboardPageClient({
 									raffle={raffle}
 									onViewDetail={(id) => router.push(`/raffle/${id}`)}
 									onViewResult={(id) => router.push(`/raffles/${id}/result`)}
+									onViewMyResult={(id) => router.push(`/my/raffles/${id}/result`)}
 								/>
 							))}
 						</div>

--- a/src/hooks/useDashboard.ts
+++ b/src/hooks/useDashboard.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react'
-// import { raffleApi, shippingApi } from '@/lib/api' // TODO: 실제 API 연동 시 사용
+import { raffleApi } from '@/lib/api' // 실제 API 연동
 import type { Winner } from '@/types/dashboard'
 import { DASHBOARD_MESSAGES } from '@/lib/constants'
 import { useToast } from '@/components/ui/Toast'
@@ -12,139 +12,152 @@ export function useDashboard() {
 	// 서버에서 prefetch하므로 loading 상태 불필요
 	const { addToast } = useToast()
 
-	const handleLockRaffle = useCallback(async () => {
-		try {
-			// TODO: 실제 API 연동 시 사용
-			// const response = await raffleApi.lock(raffleId)
-			// API 명세서 응답: { raffleId, status, lockedAt }
+	const handleLockRaffle = useCallback(
+		async (raffleId: string) => {
+			try {
+				// 실제 API 연동: POST /raffles/{raffleId}/lock
+				await raffleApi.lock(raffleId)
 
-			// Mock: API 명세서에 맞는 응답 시뮬레이션
-			// const mockLockResponse = {
-			// 	raffleId,
-			// 	status: 'LOCKED',
-			// 	lockedAt: new Date().toISOString(),
-			// }
+				// Mock: API 명세서에 맞는 응답 시뮬레이션
+				// const mockLockResponse = {
+				// 	raffleId,
+				// 	status: 'LOCKED',
+				// 	lockedAt: new Date().toISOString(),
+				// }
 
-			// TODO: 실제 API 연동 시 서버 상태 업데이트
-			// 현재는 토스트만 표시
-			addToast({
-				title: '래플 잠금 완료',
-				description: DASHBOARD_MESSAGES.RAFFLE_LOCKED,
-				variant: 'success',
-				duration: 3000,
-			})
-		} catch {
-			addToast({
-				title: '잠금 실패',
-				description: DASHBOARD_MESSAGES.RAFFLE_LOCK_FAILED,
-				variant: 'error',
-				duration: 4000,
-			})
-		}
-	}, [addToast])
+				// TODO: 실제 API 연동 시 서버 상태 업데이트
+				// 현재는 토스트만 표시
+				addToast({
+					title: '래플 잠금 완료',
+					description: DASHBOARD_MESSAGES.RAFFLE_LOCKED,
+					variant: 'success',
+					duration: 3000,
+				})
+				return true
+			} catch {
+				addToast({
+					title: '잠금 실패',
+					description: DASHBOARD_MESSAGES.RAFFLE_LOCK_FAILED,
+					variant: 'error',
+					duration: 4000,
+				})
+				return false
+			}
+		},
+		[addToast],
+	)
 
-	const handleCancelRaffle = useCallback(async () => {
-		// TODO: 커스텀 확인 다이얼로그로 교체
-		if (!confirm('정말로 이 래플을 취소하시겠습니까?')) return
+	const handleCancelRaffle = useCallback(
+		async (raffleId: string) => {
+			// TODO: 커스텀 확인 다이얼로그로 교체
+			if (!confirm('정말로 이 래플을 취소하시겠습니까?')) return
 
-		try {
-			// TODO: 실제 API 연동 시 사용
-			// const response = await raffleApi.cancel(raffleId)
-			// API 명세서 응답: { raffleId, status, cancelledAt, reason }
+			try {
+				// 실제 API 연동: POST /raffles/{raffleId}/cancel
+				await raffleApi.cancel(raffleId)
 
-			// Mock: API 명세서에 맞는 응답 시뮬레이션
-			// const mockCancelResponse = {
-			// 	raffleId,
-			// 	status: RAFFLE_STATUS.CANCELLED,
-			// 	cancelledAt: new Date().toISOString(),
-			// 	reason: '사용자 요청에 의한 취소',
-			// }
+				// Mock: API 명세서에 맞는 응답 시뮬레이션
+				// const mockCancelResponse = {
+				// 	raffleId,
+				// 	status: RAFFLE_STATUS.CANCELLED,
+				// 	cancelledAt: new Date().toISOString(),
+				// 	reason: '사용자 요청에 의한 취소',
+				// }
 
-			// TODO: 실제 API 연동 시 서버 상태 업데이트
-			// 현재는 토스트만 표시
-			addToast({
-				title: '래플 취소 완료',
-				description: DASHBOARD_MESSAGES.RAFFLE_CANCELLED,
-				variant: 'success',
-				duration: 3000,
-			})
-		} catch {
-			addToast({
-				title: '취소 실패',
-				description: DASHBOARD_MESSAGES.RAFFLE_CANCEL_FAILED,
-				variant: 'error',
-				duration: 4000,
-			})
-		}
-	}, [addToast])
+				// TODO: 실제 API 연동 시 서버 상태 업데이트
+				// 현재는 토스트만 표시
+				addToast({
+					title: '래플 취소 완료',
+					description: DASHBOARD_MESSAGES.RAFFLE_CANCELLED,
+					variant: 'success',
+					duration: 3000,
+				})
+				return true
+			} catch {
+				addToast({
+					title: '취소 실패',
+					description: DASHBOARD_MESSAGES.RAFFLE_CANCEL_FAILED,
+					variant: 'error',
+					duration: 4000,
+				})
+				return false
+			}
+		},
+		[addToast],
+	)
 
-	const handleDrawRaffle = useCallback(async () => {
-		// TODO: 커스텀 확인 다이얼로그로 교체
-		if (!confirm(DASHBOARD_MESSAGES.RAFFLE_DRAW_CONFIRM)) return
+	const handleDrawRaffle = useCallback(
+		async (raffleId: string) => {
+			// TODO: 커스텀 확인 다이얼로그로 교체
+			if (!confirm(DASHBOARD_MESSAGES.RAFFLE_DRAW_CONFIRM)) return
 
-		try {
-			// TODO: 실제 API 연동 시 사용
-			// const result = await raffleApi.draw(raffleId, { externalSeed: '1' })
-			// const winners: Winner[] = result.assignments.map((assignment, index) => ({
-			// 	id: `winner_${index + 1}`,
-			// 	raffleId,
-			// 	participantId: assignment.participantId,
-			// 	displayName: assignment.displayName,
-			// 	rank: assignment.rank,
-			// 	itemName: assignment.itemName,
-			// 	shippingStatus: SHIPPING_STATUS.PENDING,
-			// }))
+			try {
+				// 실제 API 연동
+				await raffleApi.draw(raffleId, { externalSeed: '1' })
+				// const winners: Winner[] = result.assignments.map((assignment, index) => ({
+				// 	id: `winner_${index + 1}`,
+				// 	raffleId,
+				// 	participantId: assignment.participantId,
+				// 	displayName: assignment.displayName,
+				// 	rank: assignment.rank,
+				// 	itemName: assignment.itemName,
+				// 	shippingStatus: SHIPPING_STATUS.PENDING,
+				// }))
 
-			// TODO: 실제 API 연동 시 추첨 결과 처리
-			// const mockDrawResponse = {
-			// 	raffleId,
-			// 	seed: {
-			// 		externalSeed: '1',
-			// 		participantListHash: 'abcdef1234567890',
-			// 		masterSeed: 'fedcba0987654321',
-			// 	},
-			// 	assignments: [
-			// 		{
-			// 			participantId: 'pt_999',
-			// 			displayName: 'GachaKing',
-			// 			rank: 1,
-			// 			itemName: '피카츄 넨도로이드 #1355',
-			// 		},
-			// 	],
-			// 	publishedAt: new Date().toISOString(),
-			// }
+				// TODO: 실제 API 연동 시 추첨 결과 처리
+				// const mockDrawResponse = {
+				// 	raffleId,
+				// 	seed: {
+				// 		externalSeed: '1',
+				// 		participantListHash: 'abcdef1234567890',
+				// 		masterSeed: 'fedcba0987654321',
+				// 	},
+				// 	assignments: [
+				// 		{
+				// 			participantId: 'pt_999',
+				// 			displayName: 'GachaKing',
+				// 			rank: 1,
+				// 			itemName: '피카츄 넨도로이드 #1355',
+				// 		},
+				// 	],
+				// 	publishedAt: new Date().toISOString(),
+				// }
 
-			// TODO: 실제 API 연동 시 Winner 타입으로 변환
-			// const mockWinners: Winner[] = mockDrawResponse.assignments.map((assignment, index) => ({
-			// 	id: `winner_${index + 1}`,
-			// 	raffleId,
-			// 	participantId: assignment.participantId,
-			// 	displayName: assignment.displayName,
-			// 	rank: assignment.rank,
-			// 	itemName: assignment.itemName,
-			// 	shippingStatus: SHIPPING_STATUS.PENDING,
-			// 	shipping: {
-			// 		status: SHIPPING_STATUS.PENDING,
-			// 	},
-			// }))
+				// TODO: 실제 API 연동 시 Winner 타입으로 변환
+				// const mockWinners: Winner[] = mockDrawResponse.assignments.map((assignment, index) => ({
+				// 	id: `winner_${index + 1}`,
+				// 	raffleId,
+				// 	participantId: assignment.participantId,
+				// 	displayName: assignment.displayName,
+				// 	rank: assignment.rank,
+				// 	itemName: assignment.itemName,
+				// 	shippingStatus: SHIPPING_STATUS.PENDING,
+				// 	shipping: {
+				// 		status: SHIPPING_STATUS.PENDING,
+				// 	},
+				// }))
 
-			// TODO: 실제 API 연동 시 서버 상태 업데이트
-			// 현재는 토스트만 표시
-			addToast({
-				title: '추첨 완료',
-				description: DASHBOARD_MESSAGES.RAFFLE_DRAW_COMPLETED,
-				variant: 'success',
-				duration: 3000,
-			})
-		} catch {
-			addToast({
-				title: '추첨 실패',
-				description: DASHBOARD_MESSAGES.RAFFLE_DRAW_FAILED,
-				variant: 'error',
-				duration: 4000,
-			})
-		}
-	}, [addToast])
+				// TODO: 실제 API 연동 시 서버 상태 업데이트
+				// 현재는 토스트만 표시
+				addToast({
+					title: '추첨 완료',
+					description: DASHBOARD_MESSAGES.RAFFLE_DRAW_COMPLETED,
+					variant: 'success',
+					duration: 3000,
+				})
+				return true
+			} catch {
+				addToast({
+					title: '추첨 실패',
+					description: DASHBOARD_MESSAGES.RAFFLE_DRAW_FAILED,
+					variant: 'error',
+					duration: 4000,
+				})
+				return false
+			}
+		},
+		[addToast],
+	)
 
 	const handleTrackingSubmit = useCallback((winner: Winner) => {
 		setSelectedWinner(winner)

--- a/src/lib/api-server.ts
+++ b/src/lib/api-server.ts
@@ -1,6 +1,6 @@
 import ky from 'ky'
 import type { RaffleListResponse } from '@/types'
-import type { MyRaffle } from '@/types/dashboard'
+import type { MyRaffle, ParticipatedRaffle } from '@/types/dashboard'
 
 const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL || ''
 
@@ -77,4 +77,49 @@ export const serverApiClient = {
 	// 		return []
 	// 	}
 	// },
+
+	/**
+	 * 내가 참여한 추첨 목록 (모의 API 사용)
+	 * GET http://127.0.0.1:3658/m1/1084646-1073890-default/my/raffles/participated
+	 */
+	getMyParticipatedRaffles: async (): Promise<ParticipatedRaffle[]> => {
+		try {
+			const res = await ky
+				.get('http://127.0.0.1:3658/m1/1084646-1073890-default/my/raffles/participated', {
+					timeout: 10000,
+				})
+				.json<{
+					raffles: Array<{
+						raffleId: string
+						title: string
+						entryFee: number
+						imageUrl: string
+						status: string
+						deadlineAt: string
+						myDisplayName: string
+						joinedAt: string
+					}>
+				}>()
+
+			return res.raffles.map((r) => ({
+				id: r.raffleId,
+				title: r.title,
+				imageUrl: r.imageUrl,
+				status:
+					r.status === 'PUBLISHED' ||
+					r.status === 'LOCKED' ||
+					r.status === 'DRAWN' ||
+					r.status === 'CANCELLED'
+						? (r.status as ParticipatedRaffle['status'])
+						: ('PUBLISHED' as ParticipatedRaffle['status']),
+				isWinner: false,
+				itemName: undefined,
+				shippingStatus: undefined,
+				participatedAt: r.joinedAt,
+			}))
+		} catch (error) {
+			console.error('Failed to fetch my participated raffles (mock):', error)
+			return []
+		}
+	},
 }

--- a/src/lib/api-server.ts
+++ b/src/lib/api-server.ts
@@ -1,5 +1,6 @@
 import ky from 'ky'
 import type { RaffleListResponse } from '@/types'
+import type { MyRaffleSelfResultResponse, MyWinsResponse } from '@/types'
 import type { MyRaffle, ParticipatedRaffle } from '@/types/dashboard'
 
 const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL || ''
@@ -25,27 +26,67 @@ export const serverApiClient = {
 	},
 
 	/**
+	 * 특정 추첨의 내 결과 (모의 API 사용)
+	 * GET http://127.0.0.1:3658/m1/1084646-1073890-default/my/raffles/{raffleId}/result
+	 */
+	getMyRaffleSelfResult: async (raffleId: string): Promise<MyRaffleSelfResultResponse> => {
+		try {
+			const res = await serverApi
+				.get(`my/raffles/${raffleId}/result`)
+				.json<MyRaffleSelfResultResponse>()
+			return res
+		} catch (error) {
+			console.error('Failed to fetch my raffle self result (mock):', error)
+			// 실패 시 최소 필드만 채워 반환
+			return {
+				raffleId,
+				raffleName: '',
+				status: 'PUBLISHED',
+				myParticipation: {
+					participantId: '',
+					displayName: '',
+					joinedAt: new Date().toISOString(),
+				},
+				isWinner: false,
+				winInfo: null,
+				shippingRequired: false,
+				shippingSubmitted: false,
+			}
+		}
+	},
+
+	/**
+	 * 내 당첨 목록 (모의 API 사용)
+	 * GET http://127.0.0.1:3658/m1/1084646-1073890-default/my/raffles/wins
+	 */
+	getMyWins: async (): Promise<MyWinsResponse> => {
+		try {
+			const res = await serverApi.get('my/raffles/wins').json<MyWinsResponse>()
+			return res
+		} catch (error) {
+			console.error('Failed to fetch my wins (mock):', error)
+			return { wins: [] }
+		}
+	},
+
+	/**
 	 * 내가 등록한 추첨 목록 (모의 API 사용)
 	 * 실제 인증 연동 전까지 Bearer/세션 인증은 생략
 	 * GET http://127.0.0.1:3658/m1/1084646-1073890-default/my/raffles/hosted
 	 */
 	getMyHostedRaffles: async (): Promise<MyRaffle[]> => {
 		try {
-			const res = await ky
-				.get('http://127.0.0.1:3658/m1/1084646-1073890-default/my/raffles/hosted', {
-					timeout: 10000,
-				})
-				.json<{
-					raffles: Array<{
-						raffleId: string
-						title: string
-						entryFee: number
-						imageUrl: string
-						status: string
-						deadlineAt: string
-						participantsCount: number
-					}>
-				}>()
+			const res = await serverApi.get('my/raffles/hosted').json<{
+				raffles: Array<{
+					raffleId: string
+					title: string
+					entryFee: number
+					imageUrl: string
+					status: string
+					deadlineAt: string
+					participantsCount: number
+				}>
+			}>()
 
 			// 모의 응답을 대시보드용 타입으로 매핑
 			return res.raffles.map((r) => ({
@@ -84,22 +125,18 @@ export const serverApiClient = {
 	 */
 	getMyParticipatedRaffles: async (): Promise<ParticipatedRaffle[]> => {
 		try {
-			const res = await ky
-				.get('http://127.0.0.1:3658/m1/1084646-1073890-default/my/raffles/participated', {
-					timeout: 10000,
-				})
-				.json<{
-					raffles: Array<{
-						raffleId: string
-						title: string
-						entryFee: number
-						imageUrl: string
-						status: string
-						deadlineAt: string
-						myDisplayName: string
-						joinedAt: string
-					}>
-				}>()
+			const res = await serverApi.get('my/raffles/participated').json<{
+				raffles: Array<{
+					raffleId: string
+					title: string
+					entryFee: number
+					imageUrl: string
+					status: string
+					deadlineAt: string
+					myDisplayName: string
+					joinedAt: string
+				}>
+			}>()
 
 			return res.raffles.map((r) => ({
 				id: r.raffleId,
@@ -112,6 +149,9 @@ export const serverApiClient = {
 					r.status === 'CANCELLED'
 						? (r.status as ParticipatedRaffle['status'])
 						: ('PUBLISHED' as ParticipatedRaffle['status']),
+				displayName: r.myDisplayName,
+				entryFee: Number(r.entryFee) || 0,
+				deadlineAt: r.deadlineAt,
 				isWinner: false,
 				itemName: undefined,
 				shippingStatus: undefined,

--- a/src/lib/api-server.ts
+++ b/src/lib/api-server.ts
@@ -1,6 +1,6 @@
 import ky from 'ky'
 import type { RaffleListResponse } from '@/types'
-// import type { MyRaffle, ParticipatedRaffle } from '@/types/dashboard'
+import type { MyRaffle } from '@/types/dashboard'
 
 const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL || ''
 
@@ -24,14 +24,50 @@ export const serverApiClient = {
 		}
 	},
 
-	// getMyRaffles: async (): Promise<MyRaffle[]> => {
-	// 	try {
-	// 		return await serverApi.get('raffles/my').json<MyRaffle[]>()
-	// 	} catch (error) {
-	// 		console.error('Failed to fetch my raffles:', error)
-	// 		return []
-	// 	}
-	// },
+	/**
+	 * 내가 등록한 추첨 목록 (모의 API 사용)
+	 * 실제 인증 연동 전까지 Bearer/세션 인증은 생략
+	 * GET http://127.0.0.1:3658/m1/1084646-1073890-default/my/raffles/hosted
+	 */
+	getMyHostedRaffles: async (): Promise<MyRaffle[]> => {
+		try {
+			const res = await ky
+				.get('http://127.0.0.1:3658/m1/1084646-1073890-default/my/raffles/hosted', {
+					timeout: 10000,
+				})
+				.json<{
+					raffles: Array<{
+						raffleId: string
+						title: string
+						entryFee: number
+						imageUrl: string
+						status: string
+						deadlineAt: string
+						participantsCount: number
+					}>
+				}>()
+
+			// 모의 응답을 대시보드용 타입으로 매핑
+			return res.raffles.map((r) => ({
+				id: r.raffleId,
+				title: r.title,
+				imageUrl: r.imageUrl,
+				// 알 수 없는 상태 값은 기본 'PUBLISHED'로 처리
+				status:
+					r.status === 'LOCKED' || r.status === 'DRAWN' || r.status === 'CANCELLED'
+						? (r.status as MyRaffle['status'])
+						: ('PUBLISHED' as MyRaffle['status']),
+				type: 'single',
+				currentParticipants: Math.max(0, Number(r.participantsCount) || 0),
+				maxParticipants: Math.max(0, Number(r.participantsCount) || 0),
+				deadlineAt: r.deadlineAt,
+				winners: undefined,
+			}))
+		} catch (error) {
+			console.error('Failed to fetch my hosted raffles (mock):', error)
+			return []
+		}
+	},
 
 	// getParticipatedRaffles: async (): Promise<ParticipatedRaffle[]> => {
 	// 	try {

--- a/src/lib/api-server.ts
+++ b/src/lib/api-server.ts
@@ -1,165 +1,40 @@
-import ky from 'ky'
-import type { RaffleListResponse } from '@/types'
-import type { MyRaffleSelfResultResponse, MyWinsResponse } from '@/types'
+import type { RaffleListResponse, MyRaffleSelfResultResponse, MyWinsResponse } from '@/types'
 import type { MyRaffle, ParticipatedRaffle } from '@/types/dashboard'
-
-const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL || ''
-
-const serverApi = ky.create({
-	prefixUrl: baseURL,
-	timeout: 10000,
-})
+import { raffleApi, myApi } from '@/lib/api'
 
 // 서버 컴포넌트용 API 함수들 (React Query 없이 직접 호출)
 export const serverApiClient = {
 	// 추첨 목록 조회 (서버에서 prefetch)
 	getRaffles: async (): Promise<RaffleListResponse> => {
-		try {
-			// 백엔드 서버가 없으면 에러가 발생하고 catch로 이동
-			const response = await serverApi.get('raffles').json<RaffleListResponse>()
-			return response
-		} catch (error) {
-			console.error('Failed to fetch raffles:', error)
-			// 에러 시 빈 배열 반환
-			return { items: [] }
-		}
+		// 서버 전용 래퍼: 실제 호출은 lib/api.ts로 일원화
+		return raffleApi.getList().catch(() => ({ items: [] }))
 	},
 
 	/**
-	 * 특정 추첨의 내 결과 (모의 API 사용)
-	 * GET http://127.0.0.1:3658/m1/1084646-1073890-default/my/raffles/{raffleId}/result
+	 * 특정 추첨의 내 결과 (서버 전용 래퍼)
 	 */
 	getMyRaffleSelfResult: async (raffleId: string): Promise<MyRaffleSelfResultResponse> => {
-		try {
-			const res = await serverApi
-				.get(`my/raffles/${raffleId}/result`)
-				.json<MyRaffleSelfResultResponse>()
-			return res
-		} catch (error) {
-			console.error('Failed to fetch my raffle self result (mock):', error)
-			// 실패 시 최소 필드만 채워 반환
-			return {
-				raffleId,
-				raffleName: '',
-				status: 'PUBLISHED',
-				myParticipation: {
-					participantId: '',
-					displayName: '',
-					joinedAt: new Date().toISOString(),
-				},
-				isWinner: false,
-				winInfo: null,
-				shippingRequired: false,
-				shippingSubmitted: false,
-			}
-		}
+		return myApi.getSelfResult(raffleId)
 	},
 
 	/**
-	 * 내 당첨 목록 (모의 API 사용)
-	 * GET http://127.0.0.1:3658/m1/1084646-1073890-default/my/raffles/wins
+	 * 내 당첨 목록 (서버 전용 래퍼)
 	 */
 	getMyWins: async (): Promise<MyWinsResponse> => {
-		try {
-			const res = await serverApi.get('my/raffles/wins').json<MyWinsResponse>()
-			return res
-		} catch (error) {
-			console.error('Failed to fetch my wins (mock):', error)
-			return { wins: [] }
-		}
+		return myApi.getWins().catch(() => ({ wins: [] }))
 	},
 
 	/**
-	 * 내가 등록한 추첨 목록 (모의 API 사용)
-	 * 실제 인증 연동 전까지 Bearer/세션 인증은 생략
-	 * GET http://127.0.0.1:3658/m1/1084646-1073890-default/my/raffles/hosted
+	 * 내가 등록한 추첨 목록 (서버 전용 래퍼)
 	 */
 	getMyHostedRaffles: async (): Promise<MyRaffle[]> => {
-		try {
-			const res = await serverApi.get('my/raffles/hosted').json<{
-				raffles: Array<{
-					raffleId: string
-					title: string
-					entryFee: number
-					imageUrl: string
-					status: string
-					deadlineAt: string
-					participantsCount: number
-				}>
-			}>()
-
-			// 모의 응답을 대시보드용 타입으로 매핑
-			return res.raffles.map((r) => ({
-				id: r.raffleId,
-				title: r.title,
-				imageUrl: r.imageUrl,
-				// 알 수 없는 상태 값은 기본 'PUBLISHED'로 처리
-				status:
-					r.status === 'LOCKED' || r.status === 'DRAWN' || r.status === 'CANCELLED'
-						? (r.status as MyRaffle['status'])
-						: ('PUBLISHED' as MyRaffle['status']),
-				type: 'single',
-				currentParticipants: Math.max(0, Number(r.participantsCount) || 0),
-				maxParticipants: Math.max(0, Number(r.participantsCount) || 0),
-				deadlineAt: r.deadlineAt,
-				winners: undefined,
-			}))
-		} catch (error) {
-			console.error('Failed to fetch my hosted raffles (mock):', error)
-			return []
-		}
+		return myApi.getHostedRaffles().catch(() => [])
 	},
 
-	// getParticipatedRaffles: async (): Promise<ParticipatedRaffle[]> => {
-	// 	try {
-	// 		return await serverApi.get('raffles/participated').json<ParticipatedRaffle[]>()
-	// 	} catch (error) {
-	// 		console.error('Failed to fetch participated raffles:', error)
-	// 		return []
-	// 	}
-	// },
-
 	/**
-	 * 내가 참여한 추첨 목록 (모의 API 사용)
-	 * GET http://127.0.0.1:3658/m1/1084646-1073890-default/my/raffles/participated
+	 * 내가 참여한 추첨 목록 (서버 전용 래퍼)
 	 */
 	getMyParticipatedRaffles: async (): Promise<ParticipatedRaffle[]> => {
-		try {
-			const res = await serverApi.get('my/raffles/participated').json<{
-				raffles: Array<{
-					raffleId: string
-					title: string
-					entryFee: number
-					imageUrl: string
-					status: string
-					deadlineAt: string
-					myDisplayName: string
-					joinedAt: string
-				}>
-			}>()
-
-			return res.raffles.map((r) => ({
-				id: r.raffleId,
-				title: r.title,
-				imageUrl: r.imageUrl,
-				status:
-					r.status === 'PUBLISHED' ||
-					r.status === 'LOCKED' ||
-					r.status === 'DRAWN' ||
-					r.status === 'CANCELLED'
-						? (r.status as ParticipatedRaffle['status'])
-						: ('PUBLISHED' as ParticipatedRaffle['status']),
-				displayName: r.myDisplayName,
-				entryFee: Number(r.entryFee) || 0,
-				deadlineAt: r.deadlineAt,
-				isWinner: false,
-				itemName: undefined,
-				shippingStatus: undefined,
-				participatedAt: r.joinedAt,
-			}))
-		} catch (error) {
-			console.error('Failed to fetch my participated raffles (mock):', error)
-			return []
-		}
+		return myApi.getParticipatedRaffles().catch(() => [])
 	},
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -40,7 +40,10 @@ export const raffleApi = {
 	draw: (id: string, data: DrawRequest) =>
 		api.post(`raffles/${id}/draw`, { json: data }).json<DrawResponse>(),
 	getResult: (id: string) => api.get(`raffles/${id}/result`).json<RaffleResultResponse>(),
-	getPreview: (id: string) => api.get(`raffles/${id}/preview`).json<RafflePreviewResponse>(),
+	getPreview: (id: string, externalSeed: string) =>
+		api
+			.get(`raffles/${id}/preview`, { searchParams: { externalSeed } })
+			.json<RafflePreviewResponse>(),
 	getVerifyBundle: (id: string) =>
 		api.get(`raffles/${id}/verify/bundle`).json<VerifyBundleResponse>(),
 
@@ -236,6 +239,7 @@ export const addressApi = {
 	 * 배송지 삭제
 	 * 실제 API 엔드포인트: DELETE /users/me/addresses/:id
 	 */
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	delete: (id: string): Promise<void> => {
 		// TODO: 실제 API 연동 시 아래 주석 해제하고 임시 구현 제거
 		// return api.delete(`users/me/addresses/${id}`).json<void>()

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -19,7 +19,10 @@ import type {
 	ParticipateResponse,
 	ParticipantsResponse,
 	RafflePreviewResponse,
+	MyRaffleSelfResultResponse,
+	MyWinsResponse,
 } from '@/types'
+import type { MyRaffle, ParticipatedRaffle } from '@/types/dashboard'
 
 // Raffle API
 export const raffleApi = {
@@ -69,6 +72,82 @@ export const shippingApi = {
 		api
 			.patch(`raffles/${raffleId}/winners/${participantId}/shipping`, { json: data })
 			.json<ShippingUpdateResponse>(),
+}
+
+// My API (사용자 본인 관련)
+export const myApi = {
+	// 내가 등록한 추첨 목록
+	getHostedRaffles: async (): Promise<MyRaffle[]> => {
+		const res = await api.get('my/raffles/hosted').json<{
+			raffles: Array<{
+				raffleId: string
+				title: string
+				entryFee: number
+				imageUrl: string
+				status: string
+				deadlineAt: string
+				participantsCount: number
+			}>
+		}>()
+
+		return res.raffles.map((r) => ({
+			id: r.raffleId,
+			title: r.title,
+			imageUrl: r.imageUrl,
+			status:
+				r.status === 'LOCKED' || r.status === 'DRAWN' || r.status === 'CANCELLED'
+					? (r.status as MyRaffle['status'])
+					: ('PUBLISHED' as MyRaffle['status']),
+			type: 'single',
+			currentParticipants: Math.max(0, Number(r.participantsCount) || 0),
+			maxParticipants: Math.max(0, Number(r.participantsCount) || 0),
+			deadlineAt: r.deadlineAt,
+			winners: undefined,
+		}))
+	},
+
+	// 내가 참여한 추첨 목록
+	getParticipatedRaffles: async (): Promise<ParticipatedRaffle[]> => {
+		const res = await api.get('my/raffles/participated').json<{
+			raffles: Array<{
+				raffleId: string
+				title: string
+				entryFee: number
+				imageUrl: string
+				status: string
+				deadlineAt: string
+				myDisplayName: string
+				joinedAt: string
+			}>
+		}>()
+
+		return res.raffles.map((r) => ({
+			id: r.raffleId,
+			title: r.title,
+			imageUrl: r.imageUrl,
+			status:
+				r.status === 'PUBLISHED' ||
+				r.status === 'LOCKED' ||
+				r.status === 'DRAWN' ||
+				r.status === 'CANCELLED'
+					? (r.status as ParticipatedRaffle['status'])
+					: ('PUBLISHED' as ParticipatedRaffle['status']),
+			displayName: r.myDisplayName,
+			entryFee: Number(r.entryFee) || 0,
+			deadlineAt: r.deadlineAt,
+			isWinner: false,
+			itemName: undefined,
+			shippingStatus: undefined,
+			participatedAt: r.joinedAt,
+		}))
+	},
+
+	// 특정 래플의 내 결과
+	getSelfResult: (raffleId: string) =>
+		api.get(`my/raffles/${raffleId}/result`).json<MyRaffleSelfResultResponse>(),
+
+	// 내 당첨 목록
+	getWins: () => api.get('my/raffles/wins').json<MyWinsResponse>(),
 }
 
 // 주소록 API

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -16,6 +16,7 @@ export const tierSchema = z.object({
 })
 
 // 래플 생성 폼 스키마 (deadlineAt은 submit 시 계산되므로 제외)
+// externalSeedDescription: 명세에 없으나 백엔드가 허용할 수 있으므로 optional 유지
 export const createRaffleSchema = z
 	.object({
 		title: z.string().min(1, '추첨명을 입력해주세요').max(100),
@@ -25,7 +26,7 @@ export const createRaffleSchema = z
 		maxParticipants: z.number().int().positive('최대 참여자는 1명 이상이어야 합니다'),
 		duration: z.number().int().min(1, '진행 시간은 1시간 이상이어야 합니다'),
 		imageUrl: z.string().url('올바른 이미지 URL을 입력해주세요').optional().or(z.literal('')),
-		externalSeedDescription: z.string().min(1, '외부 시드 설명을 입력해주세요'),
+		externalSeedDescription: z.string().min(1, '외부 시드 설명을 입력해주세요').optional(),
 		tiers: z.array(tierSchema).min(1, '최소 1개의 경품을 추가해주세요'),
 	})
 	.refine((data) => data.maxParticipants >= data.minParticipants, {

--- a/src/types/dashboard/index.ts
+++ b/src/types/dashboard/index.ts
@@ -24,7 +24,7 @@ export interface Winner extends ApiWinner {
 export interface MyRaffle {
 	id: string
 	title: string
-	description: string
+	description?: string
 	imageUrl: string
 	status: RaffleStatus
 	type: 'single' | 'multiple'

--- a/src/types/dashboard/index.ts
+++ b/src/types/dashboard/index.ts
@@ -39,6 +39,9 @@ export interface ParticipatedRaffle {
 	title: string
 	imageUrl: string
 	status: RaffleStatus
+	displayName?: string
+	entryFee: number
+	deadlineAt: string
 	isWinner: boolean
 	itemName?: string
 	shippingStatus?: ShippingStatus

--- a/src/types/raffle/index.ts
+++ b/src/types/raffle/index.ts
@@ -264,3 +264,38 @@ export interface Participant {
 	displayName: string
 	joinedAt: string
 }
+
+// 내 결과 조회 (GET /my/raffles/{raffleId}/result)
+export interface MyRaffleSelfResultResponse {
+	raffleId: string
+	raffleName: string
+	status: string
+	myParticipation: {
+		participantId: string
+		displayName: string
+		joinedAt: string
+	}
+	isWinner: boolean
+	winInfo: {
+		rank: number
+		prizeName: string
+		prizeImageUrl?: string
+	} | null
+	shippingRequired: boolean
+	shippingSubmitted: boolean
+}
+
+// 내 당첨 목록 (GET /my/raffles/wins)
+export interface MyWinItem {
+	raffleId: string
+	raffleName: string
+	rank: number
+	prizeName: string
+	prizeImageUrl?: string
+	shippingStatus: 'PENDING' | 'SAVED' | 'SHIPPED' | 'DELIVERED'
+	drawnAt: string
+}
+
+export interface MyWinsResponse {
+	wins: MyWinItem[]
+}

--- a/src/types/raffle/index.ts
+++ b/src/types/raffle/index.ts
@@ -14,7 +14,7 @@ export interface RaffleApiResponse {
 	deadlineAt: string
 }
 
-// 래플 상세 응답 타입
+// 래플 상세 응답 타입 (명세: GET /raffles/{raffleId})
 export interface RaffleDetailResponse {
 	id: string
 	title: string
@@ -29,7 +29,7 @@ export interface RaffleDetailResponse {
 	tiers: TierResponse[]
 	status: string
 	createdAt: string
-	participantsCount: number
+	participantDisplayNames: string[] // 명세의 필수 필드
 }
 
 export interface TierResponse {
@@ -39,7 +39,9 @@ export interface TierResponse {
 	quantity: number
 }
 
-// 래플 생성 요청 타입
+// 래플 생성 요청 타입 (명세: POST /raffles)
+// 주의: externalSeedDescription은 명세의 required에 없으나 example에는 존재
+// 백엔드 검증 정책에 따라 optional 처리
 export interface CreateRaffleRequest {
 	title: string
 	entryFee: number
@@ -48,7 +50,7 @@ export interface CreateRaffleRequest {
 	deadlineAt: string
 	imageUrl: string
 	description: string
-	externalSeedDescription: string
+	externalSeedDescription?: string // optional (명세 스키마에 미정의)
 	tiers: TierRequest[]
 }
 
@@ -242,7 +244,7 @@ export interface Winner {
 		address2?: string
 		carrier?: string
 		trackingNo?: string
-		status: string
+		status: 'PENDING' | 'SAVED' | 'SHIPPED' | 'DELIVERED' // 명세 정합성
 		updatedAt?: string
 	}
 }


### PR DESCRIPTION
## 🧠 작업 개요

- My Raffles 전반 API 연동 및 대시보드 UX 정리
- 내가 등록/참여한 추첨 목록 연동
- 내 결과/내 당첨 목록 페이지 추가


## ✨ 변경 사항

<!-- 실제 변경된 기능이나 주요 코드 수정 내용을 나열해주세요 -->

- [x] 대시보드 서버 프리패치에 myApi 적용 (/my/raffles/hosted, /my/raffles/participated)
- [x] 내 결과 페이지 추가 (/my/raffles/[raffleId]/result) 및 API 연동
- [x] 내 당첨 목록 페이지 추가 (/my/raffles/wins) 및 API 연동
- [x] 대시보드 추첨 실행(POST /raffles/{id}/draw) 실제 호출 연결, 자동 이동 제거(DRAWN 상태 갱신)

## 🧪 테스트 방법

- /dashboard 접속 → “내가 등록한/참여한 추첨” 목록 노출 확인
- 등록 카드에서 잠금 → 추첨 실행 → 상태가 DRAWN으로 바뀌는지 확인
- 참여 카드 DRAWN에서 “내 결과” 클릭 → /my/raffles/{id}/result 데이터 노출 확인
- /my/raffles/wins 접속 → 당첨 목록/배송 상태 배지/추첨일 노출 확인

## 🔗 관련 이슈

Closes #21

## 📸 스크린샷 (선택)



## ⚠️ 주의사항 / 리뷰 포인트

<!-- 코드 리뷰 시 집중해야 할 부분이나 주의해야 할 로직 -->
