### PR TITLE
백엔드 API 명세 변경에 따른 프론트엔드 타입 정의 수정 및 UI/UX 개선

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -139,7 +139,12 @@ export default function CreatePage() {
 					<CardContent className="space-y-4">
 						<div>
 							<Label htmlFor="title">추첨명 *</Label>
-							<Input id="title" {...register('title')} placeholder="예: 피카츄 넨도로이드 #1355" />
+							<Input
+								id="title"
+								{...register('title')}
+								placeholder="예: 피카츄 넨도로이드 #1355"
+								className="mt-1.5"
+							/>
 						</div>
 
 						<div>
@@ -149,6 +154,7 @@ export default function CreatePage() {
 								{...register('description')}
 								placeholder="추첨에 대한 자세한 설명을 입력해주세요"
 								rows={3}
+								className="mt-1.5"
 							/>
 						</div>
 
@@ -158,6 +164,7 @@ export default function CreatePage() {
 								id="externalSeedDescription"
 								{...register('externalSeedDescription')}
 								placeholder="예: samsung-stock-2025-10-18-close-last-digit"
+								className="mt-1.5"
 							/>
 							<p className="text-muted-foreground mt-1 text-xs">
 								공정한 추첨을 위한 외부 데이터 원천 (예: 주식 종가, 날씨 데이터 등)
@@ -170,6 +177,7 @@ export default function CreatePage() {
 								id="imageUrl"
 								{...register('imageUrl')}
 								placeholder="https://example.com/image.jpg"
+								className="mt-1.5"
 							/>
 							<p className="text-muted-foreground mt-1 text-xs">
 								미입력 시 기본 이미지가 사용됩니다
@@ -194,6 +202,7 @@ export default function CreatePage() {
 								type="number"
 								{...register('entryFee', { valueAsNumber: true })}
 								placeholder="5000"
+								className="mt-1.5"
 							/>
 						</div>
 
@@ -205,6 +214,7 @@ export default function CreatePage() {
 									type="number"
 									{...register('minParticipants', { valueAsNumber: true })}
 									placeholder="3"
+									className="mt-1.5"
 								/>
 							</div>
 							<div>
@@ -214,6 +224,7 @@ export default function CreatePage() {
 									type="number"
 									{...register('maxParticipants', { valueAsNumber: true })}
 									placeholder="10"
+									className="mt-1.5"
 								/>
 							</div>
 						</div>
@@ -226,6 +237,7 @@ export default function CreatePage() {
 								{...register('duration', { valueAsNumber: true })}
 								placeholder="24"
 								min={1}
+								className="mt-1.5"
 							/>
 							<p className="text-muted-foreground mt-1 text-xs">{duration}시간 후 자동 마감</p>
 						</div>
@@ -247,6 +259,7 @@ export default function CreatePage() {
 								onClick={() =>
 									append({ rank: fields.length + 1, name: '', quantity: 1, imageUrl: '' })
 								}
+								className="cursor-pointer"
 							>
 								<Plus className="mr-1 h-4 w-4" />
 								경품 추가
@@ -266,6 +279,7 @@ export default function CreatePage() {
 											id={`tier-name-${index}`}
 											{...register(`tiers.${index}.name`)}
 											placeholder="예: 리자몽 피규어"
+											className="mt-1.5"
 										/>
 									</div>
 									<div>
@@ -277,6 +291,7 @@ export default function CreatePage() {
 												valueAsNumber: true,
 											})}
 											min={1}
+											className="mt-1.5"
 										/>
 									</div>
 									<div>
@@ -286,6 +301,7 @@ export default function CreatePage() {
 											type="url"
 											{...register(`tiers.${index}.imageUrl`)}
 											placeholder="https://..."
+											className="mt-1.5"
 										/>
 									</div>
 								</div>
@@ -295,7 +311,7 @@ export default function CreatePage() {
 										variant="ghost"
 										size="sm"
 										onClick={() => remove(index)}
-										className="mt-8"
+										className="mt-8 cursor-pointer"
 									>
 										<X className="h-4 w-4" />
 									</Button>
@@ -311,12 +327,12 @@ export default function CreatePage() {
 						type="button"
 						variant="outline"
 						onClick={() => router.push('/')}
-						className="flex-1"
+						className="flex-1 cursor-pointer"
 						disabled={createRaffle.isPending}
 					>
 						취소
 					</Button>
-					<Button type="submit" disabled={createRaffle.isPending} className="flex-1">
+					<Button type="submit" disabled={createRaffle.isPending} className="flex-1 cursor-pointer">
 						{createRaffle.isPending ? '등록 중...' : '추첨 등록하기'}
 					</Button>
 				</div>

--- a/src/app/raffle/[id]/RaffleDetailClient.tsx
+++ b/src/app/raffle/[id]/RaffleDetailClient.tsx
@@ -84,10 +84,10 @@ export function RaffleDetailClient({ id }: RaffleDetailClientProps) {
 		if (!raffleData) return null
 
 		// 참여자 수는 participantDisplayNames 배열 길이로 계산
-		const currentParticipants = raffleData.participantDisplayNames.length
+		const currentParticipants = raffleData.participantDisplayNames?.length || 0
 
 		// 참여자 목록은 participantDisplayNames에서 직접 생성
-		const participants: Participant[] = raffleData.participantDisplayNames.map(
+		const participants: Participant[] = (raffleData.participantDisplayNames || []).map(
 			(displayName, index) => ({
 				id: `participant-${index}`, // 실제 ID는 없으므로 임시 생성
 				displayName,
@@ -96,7 +96,7 @@ export function RaffleDetailClient({ id }: RaffleDetailClientProps) {
 		)
 
 		return {
-			id: raffleData.id,
+			id: raffleData.raffleId,
 			title: raffleData.title,
 			description: raffleData.description,
 			imageUrl: raffleData.imageUrl,

--- a/src/app/raffles/[raffleId]/result/page.tsx
+++ b/src/app/raffles/[raffleId]/result/page.tsx
@@ -1,5 +1,5 @@
 import { RaffleResult } from '@/components/raffles/RaffleResult'
-import { raffleApi } from '@/lib/api'
+import type { RaffleDetailResponse } from '@/types'
 
 interface PageProps {
 	params: Promise<{ raffleId: string }>
@@ -15,8 +15,8 @@ export default async function RaffleResultPage({ params }: PageProps) {
 
 	// 래플 상세 정보 조회
 	// const raffleDetail = await raffleApi.getById(raffleId)
-	const raffleDetail = {
-		id: raffleId,
+	const raffleDetail: RaffleDetailResponse = {
+		raffleId: raffleId,
 		title: '피카츄 넌드로이드 #1',
 		description: '3만원 상당의 피카츄 넌드로이드를 5천원에!',
 		imageUrl: '/gacha.svg',

--- a/src/components/common/LayoutClient.tsx
+++ b/src/components/common/LayoutClient.tsx
@@ -18,7 +18,7 @@ export function LayoutClient({ children }: LayoutClientProps) {
 			<div className="flex flex-1 flex-col overflow-hidden">
 				<Header onMenuClick={() => setSidebarOpen(true)} />
 				<main className="flex-1 overflow-y-auto">
-					<div className="p-6">{children}</div>
+					<div className="p-10">{children}</div>
 					<Footer />
 				</main>
 			</div>

--- a/src/components/dashboard/ParticipatedRaffleCard.tsx
+++ b/src/components/dashboard/ParticipatedRaffleCard.tsx
@@ -18,7 +18,7 @@ interface ParticipatedRaffleCardProps {
 }
 
 export const ParticipatedRaffleCard = memo(
-	({ raffle, onViewDetail, onViewResult }: ParticipatedRaffleCardProps) => {
+	({ raffle, onViewDetail, onViewResult, onViewMyResult }: ParticipatedRaffleCardProps) => {
 		const [showAddressDialog, setShowAddressDialog] = useState(false)
 		let drawnLabelText = ''
 		let drawnButtonCallback = null

--- a/src/components/dashboard/ParticipatedRaffleCard.tsx
+++ b/src/components/dashboard/ParticipatedRaffleCard.tsx
@@ -113,7 +113,7 @@ export const ParticipatedRaffleCard = memo(
 							<Button
 								variant="outline"
 								onClick={() => onViewDetail(raffle.id)}
-								className="flex-1"
+								className="flex-1 cursor-pointer"
 								aria-label={`상세보기 버튼 ${raffle.title}`}
 							>
 								상세보기
@@ -123,7 +123,7 @@ export const ParticipatedRaffleCard = memo(
 									<Button
 										variant="outline"
 										onClick={drawnButtonCallback ?? undefined}
-										className="flex-1"
+										className="flex-1 cursor-pointer"
 										aria-label={`${drawnLabelText} 버튼 ${raffle.title}`}
 									>
 										{drawnLabelText}
@@ -132,7 +132,7 @@ export const ParticipatedRaffleCard = memo(
 										<Button
 											variant="outline"
 											onClick={() => onViewMyResult?.(raffle.id)}
-											className="flex-1"
+											className="flex-1 cursor-pointer"
 											aria-label={`내 결과 버튼 ${raffle.title}`}
 										>
 											내 결과

--- a/src/components/dashboard/RaffleCard.tsx
+++ b/src/components/dashboard/RaffleCard.tsx
@@ -125,44 +125,56 @@ export const RaffleCard = memo(
 	}: RaffleCardProps) => {
 		return (
 			<Card key={raffle.id}>
-				<CardHeader>
+				<CardHeader className="pb-4">
 					<div className="flex items-start gap-4">
-						<div className="relative h-12 w-12 overflow-hidden rounded-lg">
+						<div className="relative h-20 w-20 flex-shrink-0 overflow-hidden rounded-xl shadow-sm">
 							<ImageWithFallback
 								src={raffle.imageUrl}
 								alt={raffle.title}
 								className="h-full w-full object-cover"
 							/>
 						</div>
-						<div className="flex-1">
-							<div className="mb-1 flex items-center gap-2">
-								<CardTitle className="text-lg">{raffle.title}</CardTitle>
+						<div className="min-w-0 flex-1">
+							<div className="mb-2 flex items-start gap-2">
+								<CardTitle className="line-clamp-1 flex-1 text-lg font-semibold">
+									{raffle.title}
+								</CardTitle>
 								<StatusBadge status={raffle.status} />
 							</div>
-							<CardDescription className="line-clamp-2">{raffle.description}</CardDescription>
+							<CardDescription className="line-clamp-2 text-sm">
+								{raffle.description}
+							</CardDescription>
 						</div>
 					</div>
 				</CardHeader>
-				<CardContent className="space-y-4">
-					<div className="flex items-center justify-between text-sm">
-						<span className="flex items-center gap-1" aria-label="참여자 수">
-							<Users className="h-4 w-4" />
-							참여자
-						</span>
-						<span>
-							{raffle.currentParticipants}/{raffle.maxParticipants}
-						</span>
-					</div>
-
-					{raffle.status === 'PUBLISHED' && (
+				<CardContent className="space-y-3 pt-0">
+					<div className="space-y-2 rounded-lg p-3">
 						<div className="flex items-center justify-between text-sm">
-							<span className="flex items-center gap-1" aria-label="남은 시간">
-								<Clock className="h-4 w-4" />
-								남은 시간
+							<span
+								className="text-muted-foreground flex items-center gap-1.5"
+								aria-label="참여자 수"
+							>
+								<Users className="h-3.5 w-3.5" />
+								참여자
 							</span>
-							<span>{formatTimeLeft(raffle.deadlineAt)}</span>
+							<span className="font-medium">
+								{raffle.currentParticipants}/{raffle.maxParticipants}
+							</span>
 						</div>
-					)}
+
+						{raffle.status === 'PUBLISHED' && (
+							<div className="flex items-center justify-between text-sm">
+								<span
+									className="text-muted-foreground flex items-center gap-1.5"
+									aria-label="남은 시간"
+								>
+									<Clock className="h-3.5 w-3.5" />
+									남은 시간
+								</span>
+								<span className="font-medium">{formatTimeLeft(raffle.deadlineAt)}</span>
+							</div>
+						)}
+					</div>
 
 					{/* 관리 버튼들 */}
 					{renderManagementButtons(raffle, onLock, onCancel, onDraw)}
@@ -171,23 +183,25 @@ export const RaffleCard = memo(
 						<WinnerManagementSection winners={raffle.winners} onTrackingSubmit={onTrackingSubmit} />
 					)}
 
-					<div className="flex gap-2">
-						<Button
-							variant="outline"
-							onClick={() => router.push(`/raffle/${raffle.id}`)}
-							className="flex-1 cursor-pointer"
-							aria-label={`${raffle.title} 상세보기`}
-						>
-							상세보기
-						</Button>
-						{raffle.status === 'DRAWN' && (
+					{/* 하단 액션 버튼 */}
+					<div className="flex gap-2 pt-1">
+						{raffle.status === 'DRAWN' ? (
 							<Button
-								variant="outline"
+								variant="default"
 								onClick={() => router.push(`/raffles/${raffle.id}/result`)}
-								className="flex-1 cursor-pointer"
+								className="w-full cursor-pointer"
 								aria-label={`${raffle.title} 결과보기`}
 							>
-								결과보기
+								결과 보기
+							</Button>
+						) : (
+							<Button
+								variant="outline"
+								onClick={() => router.push(`/raffle/${raffle.id}`)}
+								className="w-full cursor-pointer"
+								aria-label={`${raffle.title} 상세보기`}
+							>
+								상세 보기
 							</Button>
 						)}
 					</div>

--- a/src/components/dashboard/RaffleCard.tsx
+++ b/src/components/dashboard/RaffleCard.tsx
@@ -21,7 +21,7 @@ function renderManagementButtons(
 					variant="outline"
 					size="sm"
 					onClick={() => onLock(raffle.id)}
-					className="flex-1"
+					className="flex-1 cursor-pointer"
 					aria-label={`${raffle.title} 래플 잠금`}
 				>
 					<Lock className="mr-2 h-4 w-4" />
@@ -31,7 +31,7 @@ function renderManagementButtons(
 					variant="outline"
 					size="sm"
 					onClick={() => onCancel(raffle.id)}
-					className="flex-1"
+					className="flex-1 cursor-pointer"
 					aria-label={`${raffle.title} 래플 취소`}
 				>
 					<X className="mr-2 h-4 w-4" />
@@ -47,7 +47,7 @@ function renderManagementButtons(
 				variant="default"
 				size="sm"
 				onClick={() => onDraw(raffle.id)}
-				className="w-full"
+				className="w-full cursor-pointer"
 				aria-label={`${raffle.title} 추첨 실행`}
 			>
 				<Play className="mr-2 h-4 w-4" />
@@ -94,6 +94,7 @@ function WinnerManagementSection({
 							variant="outline"
 							onClick={() => onTrackingSubmit(winner)}
 							aria-label={`${winner.displayName} 송장번호 입력`}
+							className="cursor-pointer"
 						>
 							<Truck className="mr-2 h-4 w-4" />
 							송장번호 입력
@@ -174,7 +175,7 @@ export const RaffleCard = memo(
 						<Button
 							variant="outline"
 							onClick={() => router.push(`/raffle/${raffle.id}`)}
-							className="flex-1"
+							className="flex-1 cursor-pointer"
 							aria-label={`${raffle.title} 상세보기`}
 						>
 							상세보기
@@ -183,7 +184,7 @@ export const RaffleCard = memo(
 							<Button
 								variant="outline"
 								onClick={() => router.push(`/raffles/${raffle.id}/result`)}
-								className="flex-1"
+								className="flex-1 cursor-pointer"
 								aria-label={`${raffle.title} 결과보기`}
 							>
 								결과보기

--- a/src/components/dashboard/ShippingAddressDialog.tsx
+++ b/src/components/dashboard/ShippingAddressDialog.tsx
@@ -292,7 +292,7 @@ function AddressList({ raffleId, onEdit }: AddressListProps) {
 		})
 	}
 
-	const hasAddresses = addresses && addresses?.length > 0
+	const hasAddresses = addresses && Array.isArray(addresses) && addresses.length > 0
 
 	if (!hasAddresses) {
 		return (

--- a/src/components/pages/DashboardPageClient.tsx
+++ b/src/components/pages/DashboardPageClient.tsx
@@ -85,7 +85,7 @@ export function DashboardPageClient({
 	)
 
 	return (
-		<div className="container mx-auto px-4 py-8">
+		<div className="container">
 			<div className="mb-8">
 				<h1 className="text-foreground text-2xl font-semibold">{DASHBOARD_UI_TEXT.PAGE_TITLE}</h1>
 				<p className="text-muted-foreground">{DASHBOARD_UI_TEXT.PAGE_DESCRIPTION}</p>
@@ -95,7 +95,7 @@ export function DashboardPageClient({
 				<TabsList className="grid w-full grid-cols-3 md:w-2/3" role="tablist">
 					<TabsTrigger
 						value="my-raffles"
-						className="w-full"
+						className="w-full cursor-pointer"
 						role="tab"
 						aria-controls="my-raffles-content"
 					>
@@ -103,7 +103,7 @@ export function DashboardPageClient({
 					</TabsTrigger>
 					<TabsTrigger
 						value="participated"
-						className="w-full"
+						className="w-full cursor-pointer"
 						role="tab"
 						aria-controls="participated-content"
 					>
@@ -111,7 +111,7 @@ export function DashboardPageClient({
 					</TabsTrigger>
 					<TabsTrigger
 						value="my-wins"
-						className="w-full"
+						className="w-full cursor-pointer"
 						role="tab"
 						aria-controls="my-wins-content"
 					>
@@ -134,7 +134,11 @@ export function DashboardPageClient({
 						>
 							{DASHBOARD_UI_TEXT.MY_RAFFLES_HEADER} ({displayMyRaffles.length})
 						</h2>
-						<Button onClick={() => router.push('/create')} aria-label="새로운 추첨 등록하기">
+						<Button
+							onClick={() => router.push('/create')}
+							aria-label="새로운 추첨 등록하기"
+							className="cursor-pointer"
+						>
 							<Plus className="mr-2 h-4 w-4" />
 							{DASHBOARD_UI_TEXT.CREATE_RAFFLE_BUTTON}
 						</Button>
@@ -213,7 +217,7 @@ export function DashboardPageClient({
 										<div className="flex gap-2">
 											<Button
 												variant="outline"
-												className="flex-1"
+												className="flex-1 cursor-pointer"
 												onClick={() => router.push(`/raffles/${win.raffleId}/result`)}
 												aria-label={`${win.raffleName} 결과보기`}
 											>
@@ -221,7 +225,7 @@ export function DashboardPageClient({
 											</Button>
 											<Button
 												variant="outline"
-												className="flex-1"
+												className="flex-1 cursor-pointer"
 												onClick={() => router.push(`/my/raffles/${win.raffleId}/result`)}
 												aria-label={`${win.raffleName} 내 결과`}
 											>

--- a/src/components/pages/HomePageClient.tsx
+++ b/src/components/pages/HomePageClient.tsx
@@ -12,7 +12,7 @@ import { EmptyState } from '@/components/common/EmptyState'
 import { Clock, Gift } from 'lucide-react'
 import { TIME_CONSTANTS } from '@/lib/constants'
 import { formatTimeLeft, formatPrice } from '@/lib/utils'
-import type { RaffleFilter, RaffleListResponse } from '@/types'
+import type { RaffleFilter, GetRafflesResponse, RaffleSummaryResponse } from '@/types'
 
 // 통계 카드 컴포넌트
 function StatsCard({
@@ -84,12 +84,12 @@ function RaffleCard({
 	currentTime,
 	router,
 }: {
-	raffle: RaffleListResponse['items'][0]
+	raffle: RaffleSummaryResponse
 	currentTime: number | null
 	router: ReturnType<typeof useRouter>
 }) {
 	// useMemo로 deadlineTime 메모이제이션
-	const deadlineTime = useMemo(() => new Date(raffle.deadlineAt), [raffle.deadlineAt])
+	const deadlineTime = useMemo(() => new Date(raffle.deadlineAt || ''), [raffle.deadlineAt])
 
 	// isUrgent을 useMemo로 직접 계산 (setState 불필요)
 	const isUrgent = useMemo(() => {
@@ -100,7 +100,7 @@ function RaffleCard({
 	return (
 		<div
 			className="bg-card border-border group cursor-pointer overflow-hidden rounded-xl border shadow-sm transition-all duration-200 hover:shadow-md"
-			onClick={() => router.push(`/raffle/${raffle.id}`)}
+			onClick={() => router.push(`/raffle/${raffle.raffleId}`)}
 		>
 			<div className="relative aspect-video overflow-hidden rounded-t-lg">
 				<ImageWithFallback
@@ -130,11 +130,11 @@ function RaffleCard({
 				<div className="flex items-center justify-between">
 					<div>
 						<p className="text-muted-foreground text-xs">래플 ID</p>
-						<p className="text-muted-foreground text-sm">#{raffle.id}</p>
+						<p className="text-muted-foreground text-sm">#{raffle.raffleId}</p>
 					</div>
 					<div className="text-right">
 						<p className="text-muted-foreground text-xs">참여비</p>
-						<p className="text-primary font-semibold">₩{formatPrice(raffle.entryFee)}</p>
+						<p className="text-primary font-semibold">₩{formatPrice(raffle.entryFee || 0)}</p>
 					</div>
 				</div>
 
@@ -168,13 +168,15 @@ function RaffleCard({
 				<Button
 					className="w-full"
 					size="sm"
-					disabled={raffle.status !== 'PUBLISHED' || new Date(raffle.deadlineAt) <= new Date()}
+					disabled={
+						raffle.status !== 'PUBLISHED' || new Date(raffle.deadlineAt || '') <= new Date()
+					}
 					onClick={(e) => {
 						e.stopPropagation()
-						router.push(`/raffle/${raffle.id}`)
+						router.push(`/raffle/${raffle.raffleId}`)
 					}}
 				>
-					{raffle.status === 'PUBLISHED' && new Date(raffle.deadlineAt) > new Date()
+					{raffle.status === 'PUBLISHED' && new Date(raffle.deadlineAt || '') > new Date()
 						? '참여하기'
 						: '상세보기'}
 				</Button>
@@ -196,7 +198,7 @@ function getEmptyStateMessage(filter: RaffleFilter) {
 }
 
 interface HomePageClientProps {
-	initialData: RaffleListResponse
+	initialData: GetRafflesResponse
 }
 
 export function HomePageClient({ initialData }: HomePageClientProps) {
@@ -210,13 +212,13 @@ export function HomePageClient({ initialData }: HomePageClientProps) {
 		setCurrentTime(Date.now())
 	}, [])
 
-	// 서버에서 prefetch된 데이터 사용 (중복 id 제거)
+	// 서버에서 prefetch된 데이터 사용 (중복 raffleId 제거)
 	const raffles = useMemo(() => {
-		const items = initialData.items || []
-		// Map을 사용하여 중복된 id 제거 (마지막 항목이 유지됨)
-		const uniqueMap = new Map(items.map((item) => [item.id, item]))
+		const items = initialData || []
+		// Map을 사용하여 중복된 raffleId 제거 (마지막 항목이 유지됨)
+		const uniqueMap = new Map(items.map((item) => [item.raffleId, item]))
 		return Array.from(uniqueMap.values())
-	}, [initialData.items])
+	}, [initialData])
 	const isLoading = false
 	const isError = false
 
@@ -306,7 +308,12 @@ export function HomePageClient({ initialData }: HomePageClientProps) {
 				{/* Lottery Grid */}
 				<div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
 					{filteredRaffles.map((raffle) => (
-						<RaffleCard key={raffle.id} raffle={raffle} currentTime={currentTime} router={router} />
+						<RaffleCard
+							key={raffle.raffleId}
+							raffle={raffle}
+							currentTime={currentTime}
+							router={router}
+						/>
 					))}
 				</div>
 

--- a/src/components/pages/HomePageClient.tsx
+++ b/src/components/pages/HomePageClient.tsx
@@ -166,7 +166,7 @@ function RaffleCard({
 				</div>
 
 				<Button
-					className="w-full"
+					className="w-full cursor-pointer"
 					size="sm"
 					disabled={
 						raffle.status !== 'PUBLISHED' || new Date(raffle.deadlineAt || '') <= new Date()
@@ -298,9 +298,15 @@ export function HomePageClient({ initialData }: HomePageClientProps) {
 						}}
 					>
 						<TabsList className="bg-muted">
-							<TabsTrigger value="all">전체</TabsTrigger>
-							<TabsTrigger value="active">진행중</TabsTrigger>
-							<TabsTrigger value="closed">마감</TabsTrigger>
+							<TabsTrigger value="all" className="cursor-pointer">
+								전체
+							</TabsTrigger>
+							<TabsTrigger value="active" className="cursor-pointer">
+								진행중
+							</TabsTrigger>
+							<TabsTrigger value="closed" className="cursor-pointer">
+								마감
+							</TabsTrigger>
 						</TabsList>
 					</Tabs>
 				</div>

--- a/src/components/raffles/RaffleResult.tsx
+++ b/src/components/raffles/RaffleResult.tsx
@@ -185,7 +185,7 @@ export function RaffleResult({ raffleDetail, raffleResultVideoSrc }: RaffleResul
 
 	// 래플 상세 정보
 	const {
-		id: raffleId,
+		raffleId,
 		title,
 		description,
 		imageUrl,
@@ -270,7 +270,7 @@ export function RaffleResult({ raffleDetail, raffleResultVideoSrc }: RaffleResul
 						participants={participants}
 						winnerIndex={winnerIndex}
 						externalSeedDescription={externalSeedDescription}
-						externalSeed={externalSeed}
+						externalSeed={externalSeed || null}
 						participantsCount={participantsCount}
 					/>
 					<button

--- a/src/hooks/useRaffles.ts
+++ b/src/hooks/useRaffles.ts
@@ -1,12 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
 import { raffleApi } from '@/lib/api'
-import type { RaffleListResponse } from '@/types'
+import type { GetRafflesResponse } from '@/types'
 
 // 추첨 목록 조회
 export function useRaffles() {
-	return useQuery<RaffleListResponse>({
+	return useQuery<GetRafflesResponse>({
 		queryKey: ['raffles'],
 		queryFn: raffleApi.getList,
 	})
 }
-

--- a/src/hooks/useSubmitShippingInfo.ts
+++ b/src/hooks/useSubmitShippingInfo.ts
@@ -11,7 +11,8 @@ export function useSubmitShippingInfo() {
 	const queryClient = useQueryClient()
 
 	return useMutation<ShippingInfoResponse, unknown, SubmitShippingInfoVariables>({
-		mutationFn: ({ raffleId, addressId }) => shippingApi.submitShippingInfo(raffleId, addressId),
+		mutationFn: ({ raffleId, addressId }) =>
+			shippingApi.submitShippingInfoByAddressId(raffleId, addressId),
 		onSuccess: (_data, variables) => {
 			// 후속 데이터 무효화 (필요 시 조정)
 			queryClient.invalidateQueries({ queryKey: ['participatedRaffles'] })

--- a/src/lib/api-server.ts
+++ b/src/lib/api-server.ts
@@ -1,5 +1,5 @@
 import ky from 'ky'
-import type { RaffleListResponse } from '@/types'
+import type { GetRafflesResponse } from '@/types'
 import { MyRaffle, ParticipatedRaffle } from '@/types/dashboard'
 const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL || ''
 const serverApi = ky.create({
@@ -11,15 +11,15 @@ const serverApi = ky.create({
 
 export const serverApiClient = {
 	// 추첨 목록 조회 (서버에서 prefetch)
-	getRaffles: async (): Promise<RaffleListResponse> => {
+	getRaffles: async (): Promise<GetRafflesResponse> => {
 		try {
 			// 백엔드 서버가 없으면 에러가 발생하고 catch로 이동
-			const response = await serverApi.get('raffles').json<RaffleListResponse>()
+			const response = await serverApi.get('raffles').json<GetRafflesResponse>()
 			return response
 		} catch (error) {
 			console.error('Failed to fetch raffles:', error)
-			// 에러 시 빈 배열 반환
-			return { items: [] }
+			// 에러 시 빈 배열 반환 (명세: 배열을 직접 반환)
+			return []
 		}
 	},
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -21,6 +21,7 @@ import type {
 	RafflePreviewResponse,
 	MyRaffleSelfResultResponse,
 	MyWinsResponse,
+	AddressItem,
 } from '@/types'
 import type { MyRaffle, ParticipatedRaffle } from '@/types/dashboard'
 
@@ -163,7 +164,7 @@ export const addressApi = {
 	 * 배송지 목록 조회
 	 * 실제 API 엔드포인트: GET /my/addresses
 	 */
-	getList: async (): Promise<ShippingInfoRequest[]> => {
+	getList: async (): Promise<AddressItem[]> => {
 		const response = await api.get('my/addresses').json<{
 			addresses: Array<{
 				id: string
@@ -173,16 +174,20 @@ export const addressApi = {
 				address1: string
 				address2?: string
 				isDefault?: boolean
+				label?: string
+				createdAt: string
 			}>
 		}>()
 		return response.addresses.map((addr) => ({
-			id: addr.id,
+			addressId: addr.id,
 			name: addr.name,
 			phone: addr.phone,
 			zipcode: addr.zipcode,
 			address1: addr.address1,
 			address2: addr.address2,
-			isDefault: addr.isDefault,
+			label: addr.label,
+			isDefault: addr.isDefault || false,
+			createdAt: addr.createdAt,
 		}))
 	},
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,6 @@
 import { api } from '@/lib/api-client'
 import type {
-	RaffleListResponse,
+	GetRafflesResponse,
 	RaffleDetailResponse,
 	CreateRaffleRequest,
 	CreateRaffleResponse,
@@ -27,7 +27,7 @@ import type { MyRaffle, ParticipatedRaffle } from '@/types/dashboard'
 // Raffle API
 export const raffleApi = {
 	// 기본 CRUD
-	getList: () => api.get('raffles').json<RaffleListResponse>(),
+	getList: () => api.get('raffles').json<GetRafflesResponse>(),
 	getById: (id: string) => api.get(`raffles/${id}`).json<RaffleDetailResponse>(),
 	create: (data: CreateRaffleRequest) =>
 		api.post('raffles', { json: data }).json<CreateRaffleResponse>(),

--- a/src/types/raffle/index.ts
+++ b/src/types/raffle/index.ts
@@ -1,62 +1,64 @@
-// 래플 관련 모든 타입들
+// 래플 관련 타입 정의
 
-// API 응답 타입 (실제 API 구조)
-export interface RaffleListResponse {
-	items: RaffleApiResponse[]
-}
-
-export interface RaffleApiResponse {
-	id: string
+// GET /raffles 응답 (개별 항목)
+export interface RaffleSummaryResponse {
+	raffleId: string
 	title: string
 	entryFee: number
-	imageUrl: string
 	status: string
+	imageUrl: string
 	deadlineAt: string
 }
 
-// 래플 상세 응답 타입 (명세: GET /raffles/{raffleId})
+// GET /raffles 응답 (배열)
+export type GetRafflesResponse = RaffleSummaryResponse[]
+
+// GET /raffles/{raffleId} 응답
 export interface RaffleDetailResponse {
-	id: string
+	raffleId: string
 	title: string
 	description: string
 	entryFee: number
 	minParticipants: number
 	maxParticipants: number
-	imageUrl: string
 	deadlineAt: string
+	imageUrl: string
 	externalSeedDescription: string
-	externalSeed: string | null
-	tiers: TierResponse[]
+	externalSeed?: string
+	tiers: PrizeResponse[]
 	status: string
 	createdAt: string
-	participantDisplayNames: string[] // 명세의 필수 필드
+	lockedAt?: string
+	cancelledAt?: string
+	reason?: string
+	participantsCount: number
+	participantDisplayNames?: string[]
 }
 
-export interface TierResponse {
-	rank: number
-	name: string
-	imageUrl: string
-	quantity: number
-}
-
-// 래플 생성 요청 타입 (명세: POST /raffles)
-// 주의: externalSeedDescription은 명세의 required에 없으나 example에는 존재
-// 백엔드 검증 정책에 따라 optional 처리
+// POST /raffles 요청
 export interface CreateRaffleRequest {
 	title: string
+	description: string
 	entryFee: number
 	minParticipants: number
 	maxParticipants: number
-	deadlineAt: string
 	imageUrl: string
-	description: string
-	externalSeedDescription?: string // optional (명세 스키마에 미정의)
-	tiers: TierRequest[]
+	deadlineAt: string
+	externalSeedDescription?: string
+	tiers: PrizeRequest[]
 }
 
-// 래플 생성 응답 타입 (API 명세서에 맞게 수정)
+// 경품 정보 (요청)
+export interface PrizeRequest {
+	rank: number
+	name: string
+	quantity: number
+	imageUrl: string
+}
+
+// POST /raffles 응답
 export interface CreateRaffleResponse {
-	id: string
+	raffleId: string
 	title: string
 	description: string
 	entryFee: number
@@ -65,16 +67,23 @@ export interface CreateRaffleResponse {
 	deadlineAt: string
 	imageUrl: string
 	externalSeedDescription: string
-	tiers: TierResponse[]
+	externalSeed?: string
+	tiers: PrizeResponse[]
 	status: string
 	createdAt: string
+	lockedAt?: string
+	cancelledAt?: string
+	reason?: string
+	participantsCount: number
+	participantDisplayNames?: string[]
 }
 
-export interface TierRequest {
+// 경품 정보 (응답)
+export interface PrizeResponse {
 	rank: number
 	name: string
-	quantity: number
 	imageUrl: string
+	quantity: number
 }
 
 // 필터 타입
@@ -92,12 +101,12 @@ export interface RaffleParticipation {
 	ipAddress: string
 }
 
-// 래플 참여 요청 타입
+// POST /raffles/{raffleId}/participants 요청
 export interface ParticipateRequest {
 	displayName: string
 }
 
-// 래플 참여 응답 타입
+// POST /raffles/{raffleId}/participants 응답
 export interface ParticipateResponse {
 	participantId: string
 	raffleId: string
@@ -116,18 +125,33 @@ export interface RaffleResult {
 	generatedAt: string
 }
 
-// 래플 관리 API 응답 타입들
+// POST /raffles/{raffleId}/lock 응답
 export interface RaffleLockResponse {
 	raffleId: string
 	status: string
 	lockedAt: string
 }
 
+// POST /raffles/{raffleId}/cancel 응답
 export interface RaffleCancelResponse {
 	raffleId: string
+	title: string
+	description: string
+	entryFee: number
+	minParticipants: number
+	maxParticipants: number
+	deadlineAt: string
+	imageUrl: string
+	externalSeedDescription: string
+	externalSeed?: string
+	tiers: PrizeResponse[]
 	status: string
-	cancelledAt: string
-	reason: string
+	createdAt: string
+	lockedAt?: string
+	cancelledAt?: string
+	reason?: string
+	participantsCount: number
+	participantDisplayNames?: string[]
 }
 
 // 추첨 관련 타입들
@@ -312,13 +336,14 @@ export interface WinnersResponse {
 	winners: Winner[]
 }
 
-// 참여자 목록 조회 응답 타입
+// GET /raffles/{raffleId}/participants 응답
 export interface ParticipantsResponse {
 	raffleId: string
 	participants: Participant[]
 	count: number
 }
 
+// 참여자 정보
 export interface Participant {
 	participantId: string
 	displayName: string


### PR DESCRIPTION
## 🧠 작업 개요

백엔드 API 명세 변경에 따른 프론트엔드 타입 정의 수정 및 UI/UX 개선

## ✨ 변경 사항

### API 타입 정의 수정
- [x] GET /raffles: 배열 직접 반환, `id` → `raffleId` 변경
- [x] POST /raffles: `PrizeRequest/Response` 타입명 통일
- [x] GET /raffles/{raffleId}: 추가 필드 반영 (lockedAt, cancelledAt 등)
- [x] 참여자 관련 API 타입 명세 반영
- [x] any 타입 제거 및 필수/선택 필드 구분

### UI/UX 개선
- [x] 모든 클릭 요소에 cursor-pointer 추가 (버튼, 탭)
- [x] create 페이지 Input 간격 조정 (mt-1.5)
- [x] RaffleCard 리디자인 (이미지 80px, 제목 line-clamp, 정보 박스화)

### 버그 수정
- [x] 중복 key 에러 해결 (Map으로 중복 제거)
- [x] ParticipatedRaffleCard onViewMyResult prop 누락 수정

## 🧪 테스트 방법

1. `http://localhost:3000` 홈 페이지 접속
   - 래플 목록 표시 확인
   - 탭 필터 작동 확인

2. `http://localhost:3000/create` 추첨 등록 페이지
   - Input 간격 확인
   - 버튼 호버 시 cursor-pointer 확인

## 🔗 관련 이슈

Closes #24

## ⚠️ 주의사항 / 리뷰 포인트
