### PR TITLE
fix: useImageUpload 훅의 options 의존성 문제로 인한 ImageUpload 독립성 버그 수정

### DIFF
--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useRef, useEffect } from 'react'
 import { uploadApi } from '@/lib/api'
 import type { PresignedUrlRequest } from '@/types'
 
@@ -14,56 +14,59 @@ export function useImageUpload(options?: UseImageUploadOptions) {
 	const [fileUrl, setFileUrl] = useState<string | null>(null)
 	const [error, setError] = useState<Error | null>(null)
 
-	const upload = useCallback(
-		async (file: File, purpose: 'raffle' | 'prize') => {
-			// 파일 검증
-			const maxSize = 10 * 1024 * 1024 // 10MB
-			if (file.size > maxSize) {
-				const error = new Error('파일 크기는 10MB 이하여야 합니다.')
-				setError(error)
-				setStatus('error')
-				options?.onError?.(error)
-				return
+	// options를 ref로 저장하여 최신 값을 항상 참조하도록 함
+	const optionsRef = useRef(options)
+	useEffect(() => {
+		optionsRef.current = options
+	}, [options])
+
+	const upload = useCallback(async (file: File, purpose: 'raffle' | 'prize') => {
+		// 파일 검증
+		const maxSize = 10 * 1024 * 1024 // 10MB
+		if (file.size > maxSize) {
+			const error = new Error('파일 크기는 10MB 이하여야 합니다.')
+			setError(error)
+			setStatus('error')
+			optionsRef.current?.onError?.(error)
+			return
+		}
+
+		const allowedTypes = ['image/jpeg', 'image/png', 'image/webp']
+		if (!allowedTypes.includes(file.type)) {
+			const error = new Error('이미지 파일만 업로드 가능합니다. (JPEG, PNG, WebP)')
+			setError(error)
+			setStatus('error')
+			optionsRef.current?.onError?.(error)
+			return
+		}
+
+		try {
+			setStatus('uploading')
+			setError(null)
+
+			// 1. Presigned URL 요청
+			const requestData: PresignedUrlRequest = {
+				filename: file.name,
+				contentType: file.type,
+				purpose,
 			}
 
-			const allowedTypes = ['image/jpeg', 'image/png', 'image/webp']
-			if (!allowedTypes.includes(file.type)) {
-				const error = new Error('이미지 파일만 업로드 가능합니다. (JPEG, PNG, WebP)')
-				setError(error)
-				setStatus('error')
-				options?.onError?.(error)
-				return
-			}
+			const presignedResponse = await uploadApi.getPresignedUrl(requestData)
 
-			try {
-				setStatus('uploading')
-				setError(null)
+			// 2. S3에 직접 업로드
+			await uploadApi.uploadToS3(presignedResponse.uploadUrl, file)
 
-				// 1. Presigned URL 요청
-				const requestData: PresignedUrlRequest = {
-					filename: file.name,
-					contentType: file.type,
-					purpose,
-				}
-
-				const presignedResponse = await uploadApi.getPresignedUrl(requestData)
-
-				// 2. S3에 직접 업로드
-				await uploadApi.uploadToS3(presignedResponse.uploadUrl, file)
-
-				// 3. 성공 처리
-				setFileUrl(presignedResponse.fileUrl)
-				setStatus('success')
-				options?.onSuccess?.(presignedResponse.fileUrl)
-			} catch (err) {
-				const error = err instanceof Error ? err : new Error('이미지 업로드에 실패했습니다.')
-				setError(error)
-				setStatus('error')
-				options?.onError?.(error)
-			}
-		},
-		[options],
-	)
+			// 3. 성공 처리
+			setFileUrl(presignedResponse.fileUrl)
+			setStatus('success')
+			optionsRef.current?.onSuccess?.(presignedResponse.fileUrl)
+		} catch (err) {
+			const error = err instanceof Error ? err : new Error('이미지 업로드에 실패했습니다.')
+			setError(error)
+			setStatus('error')
+			optionsRef.current?.onError?.(error)
+		}
+	}, [])
 
 	const reset = useCallback(() => {
 		setStatus('idle')


### PR DESCRIPTION
## 🧠 작업 개요

<!-- PR의 목적이나 요약을 간단하게 적어주세요 -->

예: 회원가입 페이지에 유효성 검사 추가 및 API 연동

## ✨ 변경 사항

<!-- 실제 변경된 기능이나 주요 코드 수정 내용을 나열해주세요 -->

- [x] `options`를 `useRef`로 관리하도록 구조 변경
- [x] `upload` 함수가 항상 동일한 참조를 유지하도록 수정
- [x] 실행 시점의 최신 `onSuccess`, `onError` 콜백을 사용하도록 개선

## 🧪 테스트 방법

<!-- 직접 테스트한 절차나 리뷰어가 확인할 수 있는 단계 -->

1. 이미지 업로드 성공/실패 시 콜백 정상 호출 여부 확인
2. `options` 변경 시에도 업로드 로직이 정상 동작하는지 확인

## 🔗 관련 이슈


## 📸 스크린샷 (선택)

## ⚠️ 주의사항 / 리뷰 포인트

<!-- 코드 리뷰 시 집중해야 할 부분이나 주의해야 할 로직 -->

