### PR TITLE
래플 목록 UI 정리 및 검색 상태 관리 개선

### DIFF
--- a/src/app/raffle/[id]/RaffleDetailClient.tsx
+++ b/src/app/raffle/[id]/RaffleDetailClient.tsx
@@ -284,7 +284,7 @@ export function RaffleDetailClient({ id }: RaffleDetailClientProps) {
 							alt={raffle.title}
 							className="h-full w-full object-cover"
 						/>
-						<div className="absolute top-4 left-4">
+						<div className="absolute left-4 top-4">
 							<Badge variant="default">{raffle.status}</Badge>
 						</div>
 					</div>
@@ -296,7 +296,7 @@ export function RaffleDetailClient({ id }: RaffleDetailClientProps) {
 						<CardContent className="space-y-4">
 							{raffle.prizes.map((prize) => (
 								<div key={prize.rank} className="flex items-start gap-3">
-									<div className="bg-muted relative h-16 w-16 flex-shrink-0 overflow-hidden rounded-md border">
+									<div className="relative h-16 w-16 flex-shrink-0 overflow-hidden rounded-md border bg-muted">
 										{/* eslint-disable-next-line @next/next/no-img-element */}
 										<img
 											src={prize.imageUrl || FALLBACK_IMAGE}
@@ -315,8 +315,8 @@ export function RaffleDetailClient({ id }: RaffleDetailClientProps) {
 												</Badge>
 											)}
 											<div className="min-w-0 flex-1">
-												<p className="text-sm leading-snug font-medium">{prize.name}</p>
-												<p className="text-muted-foreground mt-1 text-xs">
+												<p className="text-sm font-medium leading-snug">{prize.name}</p>
+												<p className="mt-1 text-xs text-muted-foreground">
 													수량: {prize.quantity}개
 												</p>
 											</div>
@@ -332,10 +332,10 @@ export function RaffleDetailClient({ id }: RaffleDetailClientProps) {
 				<div className="space-y-6">
 					<div>
 						<h1 className="mb-3 text-2xl font-bold lg:text-3xl">{raffle.title}</h1>
-						<p className="text-muted-foreground mb-4 text-base leading-relaxed">
+						<p className="mb-4 text-base leading-relaxed text-muted-foreground">
 							{raffle.description}
 						</p>
-						<div className="bg-muted text-muted-foreground inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs">
+						<div className="inline-flex items-center gap-1.5 rounded-md bg-muted px-2.5 py-1 text-xs text-muted-foreground">
 							<Clock className="h-3 w-3" />
 							<span>등록일</span>
 							<span className="font-medium">{raffle.createdAt.toLocaleDateString('ko-KR')}</span>
@@ -348,8 +348,8 @@ export function RaffleDetailClient({ id }: RaffleDetailClientProps) {
 						</CardHeader>
 						<CardContent>
 							<div className="flex items-center justify-between py-2">
-								<span className="text-muted-foreground text-sm">참여비</span>
-								<span className="text-primary text-xl font-bold">
+								<span className="text-sm text-muted-foreground">참여비</span>
+								<span className="text-xl font-bold text-primary">
 									₩{formatPrice(raffle.entryFee)}
 								</span>
 							</div>
@@ -404,9 +404,9 @@ export function RaffleDetailClient({ id }: RaffleDetailClientProps) {
 								</span>
 							</div>
 
-							<div className="bg-muted rounded-lg p-3">
+							<div className="rounded-lg bg-muted p-3">
 								<div className="flex items-center gap-2 text-sm">
-									<AlertCircle className="text-muted-foreground h-4 w-4" />
+									<AlertCircle className="h-4 w-4 text-muted-foreground" />
 									<span className="text-muted-foreground">외부 시드: {raffle.externalSeed}</span>
 								</div>
 							</div>
@@ -444,14 +444,14 @@ export function RaffleDetailClient({ id }: RaffleDetailClientProps) {
 												placeholder="추첨에 사용될 이름"
 												maxLength={20}
 											/>
-											<p className="text-muted-foreground mt-1 text-xs">
+											<p className="mt-1 text-xs text-muted-foreground">
 												* 개인정보가 포함되지 않도록 주의해주세요
 											</p>
 										</div>
 
-										<div className="bg-muted rounded-lg p-3">
+										<div className="rounded-lg bg-muted p-3">
 											<h4 className="mb-2 font-medium">참여 안내</h4>
-											<ul className="text-muted-foreground space-y-1 text-xs">
+											<ul className="space-y-1 text-xs text-muted-foreground">
 												<li>• 참여비: ₩{formatPrice(raffle.entryFee)}</li>
 												<li>• 참여 후 취소 불가</li>
 												<li>• 외부 시드를 통한 공정한 추첨</li>
@@ -508,8 +508,8 @@ export function RaffleDetailClient({ id }: RaffleDetailClientProps) {
 						{raffle.participants.length > 0 ? (
 							<div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
 								{raffle.participants.map((participant, index) => (
-									<div key={index} className="bg-muted flex items-center gap-2 rounded p-2">
-										<div className="bg-primary text-primary-foreground flex h-6 w-6 items-center justify-center rounded-full text-xs">
+									<div key={index} className="flex items-center gap-2 rounded bg-muted p-2">
+										<div className="flex h-6 w-6 items-center justify-center rounded-full bg-primary text-xs text-primary-foreground">
 											{index + 1}
 										</div>
 										<span className="text-sm font-medium">{participant.displayName}</span>
@@ -517,7 +517,7 @@ export function RaffleDetailClient({ id }: RaffleDetailClientProps) {
 								))}
 							</div>
 						) : (
-							<p className="text-muted-foreground text-center text-sm">아직 참여자가 없습니다</p>
+							<p className="text-center text-sm text-muted-foreground">아직 참여자가 없습니다</p>
 						)}
 					</CardContent>
 				</Card>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -11,6 +11,7 @@ import {
 import { Search, LogOut, User, Menu } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import { loginApi } from '@/lib/api'
 import { useAtom } from 'jotai'
 import { searchQueryAtom } from '@/lib/atoms/searchAtom'
@@ -36,12 +37,15 @@ export function Header({ onMenuClick }: HeaderProps) {
 			</Button>
 
 			{/* Logo (모바일) */}
-			<div className="flex items-center gap-3 lg:hidden">
+			<Link
+				href="/"
+				className="flex items-center gap-3 transition-opacity hover:opacity-80 lg:hidden"
+			>
 				<div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary">
 					<Search className="h-4 w-4 text-primary-foreground" />
 				</div>
 				<span className="text-lg font-semibold text-foreground">가차추첨</span>
-			</div>
+			</Link>
 
 			{/* Search Bar (데스크탑) */}
 			<div className="hidden max-w-md flex-1 items-center gap-4 lg:flex">

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -12,6 +12,8 @@ import { Search, LogOut, User, Menu } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { useRouter } from 'next/navigation'
 import { loginApi } from '@/lib/api'
+import { useAtom } from 'jotai'
+import { searchQueryAtom } from '@/lib/atoms/searchAtom'
 
 interface HeaderProps {
 	onMenuClick: () => void
@@ -19,6 +21,7 @@ interface HeaderProps {
 
 export function Header({ onMenuClick }: HeaderProps) {
 	const router = useRouter()
+	const [searchQuery, setSearchQuery] = useAtom(searchQueryAtom)
 
 	const handleLogout = async () => {
 		await loginApi.logout()
@@ -47,6 +50,8 @@ export function Header({ onMenuClick }: HeaderProps) {
 					<input
 						type="text"
 						placeholder="원하시는 상품을 검색해보세요"
+						value={searchQuery}
+						onChange={(e) => setSearchQuery(e.target.value)}
 						className="bg-muted/50 focus:ring-ring/20 w-full rounded-lg border border-border py-2 pl-10 pr-4 text-sm transition-all focus:outline-none focus:ring-2"
 					/>
 				</div>

--- a/src/components/common/LayoutClient.tsx
+++ b/src/components/common/LayoutClient.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { usePathname } from 'next/navigation'
 import { Header } from '@/components/common/Header'
 import { Sidebar } from '@/components/common/Sidebar'
 import { Footer } from '@/components/common/Footer'
@@ -11,6 +12,13 @@ interface LayoutClientProps {
 
 export function LayoutClient({ children }: LayoutClientProps) {
 	const [sidebarOpen, setSidebarOpen] = useState(false)
+	const pathname = usePathname()
+	const isLoginPage = pathname === '/login'
+
+	// 로그인 페이지에서는 헤더와 사이드바를 표시하지 않음
+	if (isLoginPage) {
+		return <>{children}</>
+	}
 
 	return (
 		<div className="flex h-screen overflow-hidden">

--- a/src/components/common/LayoutClient.tsx
+++ b/src/components/common/LayoutClient.tsx
@@ -26,7 +26,7 @@ export function LayoutClient({ children }: LayoutClientProps) {
 			<div className="flex flex-1 flex-col overflow-hidden">
 				<Header onMenuClick={() => setSidebarOpen(true)} />
 				<main className="flex-1 overflow-y-auto">
-					<div className="p-10">{children}</div>
+					<div className="p-5 lg:p-10">{children}</div>
 					<Footer />
 				</main>
 			</div>

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -28,7 +28,7 @@ function renderNavigationItems(
 					'flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors',
 					isActive
 						? 'bg-primary text-primary-foreground shadow-sm'
-						: 'text-muted-foreground hover:text-foreground hover:bg-accent',
+						: 'text-muted-foreground hover:bg-accent hover:text-foreground',
 				)}
 			>
 				<item.icon className="h-5 w-5" />
@@ -46,7 +46,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
 			{/* 오버레이 (모바일) */}
 			<div
 				className={cn(
-					'fixed inset-0 z-[30] bg-black/50 transition-opacity duration-300 lg:hidden',
+					'fixed inset-0 z-[40] bg-black/50 transition-opacity duration-300 lg:hidden',
 					isOpen ? 'opacity-100' : 'pointer-events-none opacity-0',
 				)}
 				onClick={onClose}
@@ -55,28 +55,28 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
 			{/* Sidebar */}
 			<div
 				className={cn(
-					'bg-card border-border flex h-full w-64 flex-col border-r',
+					'flex h-full w-64 flex-col border-r border-border bg-card',
 					// 모바일: fixed, 슬라이드
-					'fixed top-0 left-0 z-[20] h-screen shadow-2xl transition-transform duration-300 ease-out lg:relative lg:translate-x-0 lg:shadow-none',
+					'fixed left-0 top-0 z-[50] h-screen shadow-2xl transition-transform duration-300 ease-out lg:relative lg:translate-x-0 lg:shadow-none',
 					isOpen ? 'translate-x-0' : '-translate-x-full',
 				)}
 			>
 				{/* Logo */}
-				<div className="border-border flex h-16 items-center justify-between border-b px-6">
+				<div className="flex h-16 items-center justify-between border-b border-border px-6">
 					<Link
 						href="/"
 						onClick={onClose}
 						className="flex items-center gap-3 transition-opacity hover:opacity-80"
 					>
-						<div className="bg-primary flex h-8 w-8 items-center justify-center rounded-lg">
-							<Gift className="text-primary-foreground h-5 w-5" />
+						<div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary">
+							<Gift className="h-5 w-5 text-primary-foreground" />
 						</div>
-						<span className="text-foreground text-lg font-semibold">가차추첨</span>
+						<span className="text-lg font-semibold text-foreground">가차추첨</span>
 					</Link>
 					{/* 모바일 닫기 버튼 */}
 					<button
 						onClick={onClose}
-						className="hover:bg-accent rounded-lg p-2 transition-colors lg:hidden"
+						className="rounded-lg p-2 transition-colors hover:bg-accent lg:hidden"
 					>
 						<X className="h-5 w-5" />
 					</button>
@@ -90,7 +90,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
 				</nav>
 
 				{/* Bottom Navigation */}
-				<div className="border-border absolute right-0 bottom-0 left-0 border-t p-4">
+				<div className="absolute bottom-0 left-0 right-0 border-t border-border p-4">
 					<div className="space-y-1">
 						{renderNavigationItems(SIDEBAR_BOTTOM_ITEMS, pathname, onClose)}
 					</div>

--- a/src/components/login/LoginCard.tsx
+++ b/src/components/login/LoginCard.tsx
@@ -27,7 +27,7 @@ export function LoginCard() {
 	}
 
 	return (
-		<div className="relative flex min-h-[calc(100vh-112px)] items-center justify-center px-4 py-10 sm:px-6">
+		<div className="relative flex min-h-screen items-center justify-center px-4 py-10 sm:px-6">
 			{/* 배경 블러 원들 */}
 			<div className="pointer-events-none absolute inset-0 -z-10">
 				<div className="absolute left-10 top-24 h-56 w-56 rounded-full bg-purple-400/25 blur-3xl dark:bg-purple-500/25" />

--- a/src/components/pages/HomePageClient.tsx
+++ b/src/components/pages/HomePageClient.tsx
@@ -214,12 +214,18 @@ export function HomePageClient() {
 
 	const { data: initialData } = useRaffles()
 
-	// 서버에서 prefetch된 데이터 사용 (중복 raffleId 제거)
+	// 서버에서 prefetch된 데이터 사용 (중복 raffleId 제거 및 최신순 정렬)
 	const raffles = useMemo(() => {
 		const items = initialData || []
 		// Map을 사용하여 중복된 raffleId 제거 (마지막 항목이 유지됨)
 		const uniqueMap = new Map(items.map((item) => [item.raffleId, item]))
-		return Array.from(uniqueMap.values())
+		const uniqueItems = Array.from(uniqueMap.values())
+		// 최신순 정렬 (deadlineAt 기준 내림차순)
+		return uniqueItems.sort((a, b) => {
+			const dateA = new Date(a.deadlineAt).getTime()
+			const dateB = new Date(b.deadlineAt).getTime()
+			return dateB - dateA // 내림차순 (최신이 위로)
+		})
 	}, [initialData])
 	const isLoading = false
 	const isError = false

--- a/src/components/pages/HomePageClient.tsx
+++ b/src/components/pages/HomePageClient.tsx
@@ -15,6 +15,8 @@ import { formatTimeLeft, formatPrice } from '@/lib/utils'
 import type { RaffleFilter, RaffleSummaryResponse } from '@/types'
 import { useRaffles } from '@/hooks/useRaffles'
 import { EventCard } from '@/components/dashboard/EventCard'
+import { useAtom } from 'jotai'
+import { searchQueryAtom } from '@/lib/atoms/searchAtom'
 
 // 통계 카드 컴포넌트
 function StatsCard({
@@ -201,6 +203,7 @@ function getEmptyStateMessage(filter: RaffleFilter) {
 
 export function HomePageClient() {
 	const router = useRouter()
+	const [searchQuery] = useAtom(searchQueryAtom)
 	const [filter, setFilter] = useState<RaffleFilter>('all')
 	const [currentTime, setCurrentTime] = useState<number | null>(null)
 	// 클라이언트에서만 시간 설정 (hydration 이슈 방지)
@@ -236,28 +239,39 @@ export function HomePageClient() {
 		}
 	}, [raffles, currentTime])
 
-	// 필터링 (currentTime이 설정된 후에만 실행)
-	const filteredRaffles = raffles.filter((raffle) => {
-		// 전체 - 모든 항목 표시
-		if (filter === 'all') return true
+	// 필터링 및 검색 (currentTime이 설정된 후에만 실행)
+	const filteredRaffles = useMemo(() => {
+		return raffles.filter((raffle) => {
+			// 검색어 필터링 (제목으로 검색)
+			if (searchQuery.trim()) {
+				const query = searchQuery.trim().toLowerCase()
+				if (!raffle.title.toLowerCase().includes(query)) {
+					return false
+				}
+			}
 
-		// 진행중 - PUBLISHED 상태이면서 마감시간이 지나지 않은 항목
-		if (filter === 'active' && currentTime) {
-			return raffle.status === 'PUBLISHED' && new Date(raffle.deadlineAt).getTime() > currentTime
-		}
+			// 상태 필터링
+			// 전체 - 모든 항목 표시
+			if (filter === 'all') return true
 
-		// 마감 - LOCKED, DRAWN, CANCELLED 또는 마감시간이 지난 PUBLISHED 항목
-		if (filter === 'closed' && currentTime) {
-			return (
-				raffle.status === 'LOCKED' ||
-				raffle.status === 'DRAWN' ||
-				raffle.status === 'CANCELLED' ||
-				(raffle.status === 'PUBLISHED' && new Date(raffle.deadlineAt).getTime() <= currentTime)
-			)
-		}
+			// 진행중 - PUBLISHED 상태이면서 마감시간이 지나지 않은 항목
+			if (filter === 'active' && currentTime) {
+				return raffle.status === 'PUBLISHED' && new Date(raffle.deadlineAt).getTime() > currentTime
+			}
 
-		return true
-	})
+			// 마감 - LOCKED, DRAWN, CANCELLED 또는 마감시간이 지난 PUBLISHED 항목
+			if (filter === 'closed' && currentTime) {
+				return (
+					raffle.status === 'LOCKED' ||
+					raffle.status === 'DRAWN' ||
+					raffle.status === 'CANCELLED' ||
+					(raffle.status === 'PUBLISHED' && new Date(raffle.deadlineAt).getTime() <= currentTime)
+				)
+			}
+
+			return true
+		})
+	}, [raffles, searchQuery, filter, currentTime])
 
 	// 로딩 상태
 	if (isLoading) {

--- a/src/lib/atoms/searchAtom.ts
+++ b/src/lib/atoms/searchAtom.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai'
+
+export const searchQueryAtom = atom<string>('')


### PR DESCRIPTION
## 🧠 작업 개요

래플 상세 페이지, 홈 페이지, 공통 레이아웃 전반의 UI 구조 및 상태 관리 로직을 정리하고  
검색 기능 추가와 일부 레이아웃/스타일 개선을 진행

## ✨ 변경 사항

- [x] 홈 페이지에서 래플 목록 중복 제거 및 최신순 정렬 로직 개선
- [x] 제목 기준 검색 기능 추가 (Jotai `searchQueryAtom` 사용)
- [x] 헤더 검색 입력값을 전역 상태로 관리하도록 수정
- [x] 로그인 페이지에서 공통 레이아웃(헤더/사이드바) 미노출 처리
- [x] 래플 상세 페이지 UI 정렬 및 클래스 순서 정리
- [x] 사이드바, 헤더, 카드 컴포넌트의 스타일 및 z-index 정리
- [x] 외부 시드 정보 영역 UI 정리

## 🧪 테스트 방법

1. 홈 화면 진입 후 래플 목록이 최신순으로 정상 노출되는지 확인
2. 검색창에 키워드 입력 시 제목 기준으로 래플이 필터링되는지 확인
3. 래플 상세 페이지에서 상품/참여자/외부 시드 정보 UI 확인
4. 로그인 페이지 접속 시 헤더/사이드바가 표시되지 않는지 확인
5. 모바일 환경에서 사이드바 열기/닫기 동작 확인

## 🔗 관련 이슈

## 📸 스크린샷 (선택)



## ⚠️ 주의사항 / 리뷰 포인트


